### PR TITLE
feat(dynamodb): add parallel scan support to export command

### DIFF
--- a/commands/dynamodb.py
+++ b/commands/dynamodb.py
@@ -36,6 +36,12 @@ def dynamodb(ctx: AppContext):
     default=None,
     help="Maximum number of items to export (useful for debugging/testing)",
 )
+@click.option(
+    "--segments",
+    type=int,
+    default=1,
+    help="Number of parallel scan segments (default: 1 = sequential). Higher values speed up large table exports.",
+)
 @click.pass_obj
 def export(
     ctx: AppContext,
@@ -43,6 +49,7 @@ def export(
     output_dir: str | None,
     filter_expressions: tuple[str, ...],
     limit: int | None,
+    segments: int,
 ) -> None:
     if output_dir is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -54,7 +61,7 @@ def export(
         condition = _parse_multiple_filters(filter_expressions)
 
     exporter = GenericDynamodbExporter(ctx.profile, table)
-    exporter.export(output_dir, condition, limit)
+    exporter.export(output_dir, condition, limit, segments)
 
 
 def _parse_multiple_filters(filter_expressions: tuple[str, ...]) -> ConditionBase | None:

--- a/commands/dynamodb.py
+++ b/commands/dynamodb.py
@@ -38,7 +38,7 @@ def dynamodb(ctx: AppContext):
 )
 @click.option(
     "--segments",
-    type=int,
+    type=click.IntRange(min=1, max=256),
     default=1,
     help="Number of parallel scan segments (default: 1 = sequential). Higher values speed up large table exports.",
 )

--- a/commands/services/dynamodb_exporter.py
+++ b/commands/services/dynamodb_exporter.py
@@ -43,6 +43,7 @@ class GenericDynamodbExporter:
         self.dynamodb = self.session.client("dynamodb")
         self.table = self._get_table()
         self.table_name: str = self.table.name
+        self._thread_local = threading.local()
 
     def _get_table(self) -> Any:
         response = self.dynamodb.list_tables()
@@ -86,8 +87,10 @@ class GenericDynamodbExporter:
         return item
 
     def _get_table_for_thread(self) -> Any:
-        session = boto3.Session(profile_name=self.profile) if self.profile else boto3.Session()
-        return session.resource("dynamodb").Table(self.table_name)
+        if not hasattr(self._thread_local, "table"):
+            session = boto3.Session(profile_name=self.profile) if self.profile else boto3.Session()
+            self._thread_local.table = session.resource("dynamodb").Table(self.table_name)
+        return self._thread_local.table
 
     def _save_items_to_file(
         self,

--- a/commands/services/dynamodb_exporter.py
+++ b/commands/services/dynamodb_exporter.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import base64
 import json
 import logging
+import math
+import threading
 import zlib
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -32,6 +37,7 @@ class DynamoDBEncoder(json.JSONEncoder):
 
 class GenericDynamodbExporter:
     def __init__(self, profile: str | None, table_name_substring: str) -> None:
+        self.profile = profile
         self.table_name_substring = table_name_substring
         self.session = boto3.Session(profile_name=profile) if profile else boto3.Session()
         self.dynamodb = self.session.client("dynamodb")
@@ -79,12 +85,24 @@ class GenericDynamodbExporter:
 
         return item
 
+    def _get_table_for_thread(self) -> Any:
+        session = boto3.Session(profile_name=self.profile) if self.profile else boto3.Session()
+        return session.resource("dynamodb").Table(self.table_name)
+
     def _save_items_to_file(
-        self, items: list[dict[str, Any]], batch_count: int, output_folder: str
+        self,
+        items: list[dict[str, Any]],
+        batch_count: int,
+        output_folder: str,
+        segment: int | None = None,
     ) -> None:
         processed_items = [self._process_item(item) for item in items]
 
-        output_file = Path(output_folder) / f"batch_{batch_count:05d}.jsonl"
+        if segment is not None:
+            output_file = Path(output_folder) / f"segment_{segment:03d}_batch_{batch_count:05d}.jsonl"
+        else:
+            output_file = Path(output_folder) / f"batch_{batch_count:05d}.jsonl"
+
         with open(output_file, "w", encoding="utf-8") as file:
             for item in processed_items:
                 json.dump(item, file, cls=DynamoDBEncoder)
@@ -93,62 +111,150 @@ class GenericDynamodbExporter:
         logger.info(f"Saved {len(processed_items)} items to {output_file}")
 
 
+    def _run_scan_loop(
+        self,
+        table: Any,
+        scan_kwargs: dict[str, Any],
+        limit: int | None,
+        callback: Any,
+        progress_bar: tqdm,
+        progress_lock: threading.Lock | None = None,
+    ) -> tuple[int, int]:
+        batch_count = 0
+        items_processed = 0
+        items_scanned = 0
+
+        response = table.scan(**scan_kwargs)
+        items = response.get("Items", [])
+
+        while True:
+            items_scanned += response.get("ScannedCount", 0)
+
+            if items:
+                if limit is not None:
+                    items = items[: limit - items_processed]
+
+                batch_count += 1
+                items_processed += len(items)
+
+                if progress_lock:
+                    with progress_lock:
+                        progress_bar.update(len(items))
+                else:
+                    progress_bar.update(len(items))
+
+                callback(items, batch_count)
+
+            if "LastEvaluatedKey" not in response:
+                break
+
+            if limit is not None and items_processed >= limit:
+                break
+
+            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+            response = table.scan(**scan_kwargs)
+            items = response.get("Items", [])
+
+        return items_processed, items_scanned
+
     def _iterate_batches_scan(
         self,
         condition: ConditionBase | None,
         callback: Any,
         limit: int | None = None,
     ) -> None:
-        scan_kwargs = {}
+        scan_kwargs: dict[str, Any] = {}
         if condition:
             scan_kwargs["FilterExpression"] = condition
 
-        batch_count = 0
-        items_processed = 0
-        items_scanned = 0
-
         logger.info("Initiating table scan (this may take a while for large tables)...")
-        response = self.table.scan(**scan_kwargs)
-        items = response.get("Items", [])
 
         with tqdm(desc="Scanning table", unit="items") as progress_bar:
-            while True:
-                items_scanned += response.get("ScannedCount", 0)
-                progress_bar.set_postfix(scanned=items_scanned, matched=items_processed)
+            items_processed, _ = self._run_scan_loop(self.table, scan_kwargs, limit, callback, progress_bar)
 
-                if items:
-                    if limit is not None:
-                        remaining = limit - items_processed
-                        items = items[:remaining]
+        logger.info(f"Completed scan. Processed {items_processed} items")
 
-                    batch_count += 1
-                    items_processed += len(items)
-                    progress_bar.update(len(items))
-                    callback(items, batch_count)
+    def _scan_segment(
+        self,
+        segment: int,
+        total_segments: int,
+        condition: ConditionBase | None,
+        callback: Any,
+        limit: int | None,
+        progress_bar: tqdm,
+        progress_lock: threading.Lock,
+    ) -> tuple[int, int]:
+        table = self._get_table_for_thread()
+        scan_kwargs: dict[str, Any] = {"Segment": segment, "TotalSegments": total_segments}
+        if condition:
+            scan_kwargs["FilterExpression"] = condition
 
-                if "LastEvaluatedKey" not in response:
-                    break
+        def segment_callback(items: list, batch_count: int) -> None:
+            callback(items, segment, batch_count)
 
-                if limit is not None and items_processed >= limit:
-                    break
+        return self._run_scan_loop(table, scan_kwargs, limit, segment_callback, progress_bar, progress_lock)
 
-                scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-                response = self.table.scan(**scan_kwargs)
-                items = response.get("Items", [])
+    def _iterate_batches_parallel_scan(
+        self,
+        condition: ConditionBase | None,
+        callback: Any,
+        limit: int | None,
+        total_segments: int,
+    ) -> None:
+        logger.info(
+            f"Initiating parallel table scan with {total_segments} segments "
+            "(this may take a while for large tables)..."
+        )
 
-        logger.info(f"Completed scan. Processed {items_processed} items in {batch_count} batches")
+        progress_lock = threading.Lock()
+        total_items_processed = 0
+        total_items_scanned = 0
+        per_segment_limit = math.ceil(limit / total_segments) if limit is not None else None
+
+        with tqdm(desc="Scanning table (parallel)", unit="items") as progress_bar:
+            with ThreadPoolExecutor(max_workers=total_segments) as executor:
+                futures = {
+                    executor.submit(
+                        self._scan_segment,
+                        segment,
+                        total_segments,
+                        condition,
+                        callback,
+                        per_segment_limit,
+                        progress_bar,
+                        progress_lock,
+                    ): segment
+                    for segment in range(total_segments)
+                }
+
+                for future in as_completed(futures):
+                    items_processed, items_scanned = future.result()
+                    total_items_processed += items_processed
+                    total_items_scanned += items_scanned
+
+        logger.info(
+            f"Completed parallel scan. Processed {total_items_processed} items "
+            f"across {total_segments} segments"
+        )
 
     def export(
         self,
         output_folder: str,
         condition: ConditionBase | None = None,
         limit: int | None = None,
+        total_segments: int = 1,
     ) -> None:
         Path(output_folder).mkdir(parents=True, exist_ok=True)
 
         logger.info(f"Starting export of table {self.table_name} to {output_folder}")
 
-        def save_callback(items: list, batch_count: int) -> None:
-            self._save_items_to_file(items, batch_count, output_folder)
+        if total_segments > 1:
+            def parallel_save_callback(items: list, segment: int, batch_count: int) -> None:
+                self._save_items_to_file(items, batch_count, output_folder, segment=segment)
 
-        self._iterate_batches_scan(condition, save_callback, limit)
+            self._iterate_batches_parallel_scan(condition, parallel_save_callback, limit, total_segments)
+        else:
+            def save_callback(items: list, batch_count: int) -> None:
+                self._save_items_to_file(items, batch_count, output_folder)
+
+            self._iterate_batches_scan(condition, save_callback, limit)

--- a/commands/services/tests/test_dynamodb_exporter.py
+++ b/commands/services/tests/test_dynamodb_exporter.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import math
 import zlib
 from datetime import date, datetime
 from decimal import Decimal
@@ -293,3 +294,68 @@ def test_dynamodb_encoder_date():
     data = {"date_field": d}
     result = json.dumps(data, cls=DynamoDBEncoder)
     assert result == '{"date_field": "2024-01-15"}'
+
+
+def test_save_items_to_file_with_segment(mock_exporter, sample_uncompressed_item, tmp_path):
+    items = [sample_uncompressed_item]
+    mock_exporter._save_items_to_file(items, 1, str(tmp_path), segment=2)
+
+    output_file = tmp_path / "segment_002_batch_00001.jsonl"
+    assert output_file.exists()
+
+    with open(output_file) as file:
+        lines = file.readlines()
+        assert len(lines) == 1
+        saved_item = json.loads(lines[0])
+        assert saved_item == sample_uncompressed_item
+
+
+def test_export_parallel_scan_creates_segment_files(mock_exporter, sample_uncompressed_item, tmp_path):
+    total_segments = 3
+
+    mock_table = Mock()
+    mock_table.scan.return_value = {"Items": [sample_uncompressed_item], "ScannedCount": 1}
+
+    with patch.object(mock_exporter, "_get_table_for_thread", return_value=mock_table):
+        mock_exporter.export(str(tmp_path), total_segments=total_segments)
+
+    segment_files = list(tmp_path.glob("segment_*_batch_*.jsonl"))
+    assert len(segment_files) == total_segments
+    segments_seen = {int(f.name.split("_")[1]) for f in segment_files}
+    assert segments_seen == {0, 1, 2}
+
+
+def test_export_parallel_scan_distributes_limit(mock_exporter, sample_uncompressed_item, tmp_path):
+    total_segments = 4
+    limit = 10
+
+    captured_scan_kwargs = []
+    original_items = [{"PK0": f"Resource:{i}"} for i in range(3)]
+
+    def mock_scan(**kwargs):
+        captured_scan_kwargs.append(kwargs)
+        return {"Items": original_items, "ScannedCount": 3}
+
+    mock_table = Mock()
+    mock_table.scan.side_effect = mock_scan
+
+    with patch.object(mock_exporter, "_get_table_for_thread", return_value=mock_table):
+        mock_exporter.export(str(tmp_path), limit=limit, total_segments=total_segments)
+
+    per_segment_limit = math.ceil(limit / total_segments)
+    assert per_segment_limit == 3
+    for kwargs in captured_scan_kwargs:
+        assert kwargs.get("TotalSegments") == total_segments
+
+
+def test_export_sequential_scan_creates_batch_files(mock_exporter, sample_uncompressed_item, tmp_path):
+    mock_exporter.table.scan.return_value = {
+        "Items": [sample_uncompressed_item],
+        "ScannedCount": 1,
+    }
+
+    mock_exporter.export(str(tmp_path), total_segments=1)
+
+    batch_files = list(tmp_path.glob("batch_*.jsonl"))
+    assert len(batch_files) == 1
+    assert not list(tmp_path.glob("segment_*.jsonl"))


### PR DESCRIPTION
## Summary
- Add `--segments` option to the `dynamodb export` command to scan the table across N parallel workers using DynamoDB's parallel scan API
- Limit is distributed evenly across segments (`ceil(limit / segments)`) when used together
- Extract shared `_run_scan_loop` to eliminate code duplication between sequential and parallel scan paths

https://sikt.atlassian.net/browse/NP-50989