### PR TITLE
feat(reports): replace author-shares with remote endpoint

### DIFF
--- a/commands/reports.py
+++ b/commands/reports.py
@@ -17,36 +17,16 @@ def reports(ctx: AppContext):
 
 
 @reports.command(name="author-shares")
-@click.option("--institution-id", "-i", required=True, help="Cristin institution ID (e.g. 185.90.0.0).")
 @click.option("--year", default=lambda: datetime.now().year, show_default="current year", type=int)
-@click.option("--output", default=None, help="Output filename (defaults to author_shares_<profile>_<id>_<year>_<timestamp>.xlsx)")
+@click.option("--output", default=None, help="Output filename (defaults to author_shares_<profile>_<year>_<timestamp>.xlsx)")
 @click.pass_obj
-def author_shares(ctx: AppContext, institution_id: str, year: int, output: str | None):
+def author_shares(ctx: AppContext, year: int, output: str | None):
     service = ScientificIndexService(ctx.profile)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = output or f"author_shares_{ctx.profile}_{institution_id}_{year}_{timestamp}.xlsx"
-    click.echo(f"Fetching report for {institution_id} ({year})...")
-    data = service.get_institution_report(institution_id, year)
+    filename = output or f"author_shares_{ctx.profile}_{year}_{timestamp}.xlsx"
+    click.echo(f"Fetching author shares report for {year}...")
+    data = service.get_all_institutions_report(year)
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         warnings.filterwarnings("ignore", message="Ignoring URL", category=UserWarning)
     pl.read_excel(io.BytesIO(data)).write_excel(filename, autofit=True, table_style="Table Style Medium 9")
     click.echo(f"Saved to {filename}")
-
-
-@reports.command(name="author-shares-all")
-@click.option("--year", default=lambda: datetime.now().year, show_default="current year", type=int)
-@click.option("--output", default=None, help="Output filename (defaults to author_shares_<profile>_all_<year>_<timestamp>.xlsx)")
-@click.pass_obj
-def author_shares_all(ctx: AppContext, year: int, output: str | None):
-    service = ScientificIndexService(ctx.profile)
-    try:
-        merged = service.get_all_institution_reports(ctx.profile, year)
-    except ValueError as error:
-        click.echo(str(error), err=True)
-        raise click.Abort()
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = output or f"author_shares_{ctx.profile}_all_{year}_{timestamp}.xlsx"
-    if not logging.getLogger().isEnabledFor(logging.DEBUG):
-        warnings.filterwarnings("ignore", message="Ignoring URL", category=UserWarning)
-    merged.write_excel(filename, autofit=True, table_style="Table Style Medium 9")
-    click.echo(f"Merged {len(merged)} rows into {filename}")

--- a/commands/reports.py
+++ b/commands/reports.py
@@ -24,7 +24,7 @@ def author_shares(ctx: AppContext, year: int, output: str | None):
     service = ScientificIndexService(ctx.profile)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     filename = output or f"author_shares_{ctx.profile}_{year}_{timestamp}.xlsx"
-    click.echo(f"Fetching author shares report for {year}...")
+    click.echo(f"Fetching author shares report for {year} (may take a few minutes)...")
     data = service.get_all_institutions_report(year)
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         warnings.filterwarnings("ignore", message="Ignoring URL", category=UserWarning)

--- a/commands/services/scientific_index_api.py
+++ b/commands/services/scientific_index_api.py
@@ -58,4 +58,7 @@ class ScientificIndexService:
         }
         response = requests.get(url, headers=headers)
         response.raise_for_status()
-        return response.content
+        presigned_url = response.json()["uri"]
+        xlsx_response = requests.get(presigned_url)
+        xlsx_response.raise_for_status()
+        return xlsx_response.content

--- a/commands/services/scientific_index_api.py
+++ b/commands/services/scientific_index_api.py
@@ -1,3 +1,4 @@
+import time
 import boto3
 import json
 import logging
@@ -8,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 XLSX_AUTHOR_SHARES_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares"
 ALL_INSTITUTIONS_REPORT_PATH = "scientific-index/reports/{year}/institutions"
+POLL_INTERVAL_SECONDS = 5
 
 
 class ScientificIndexService:
@@ -50,7 +52,7 @@ class ScientificIndexService:
             self.token = self._get_cognito_token()
         return self.token
 
-    def get_all_institutions_report(self, year: int) -> bytes:
+    def get_all_institutions_report(self, year: int, timeout_minutes: int = 5) -> bytes:
         url = f"https://{self.api_domain}/{ALL_INSTITUTIONS_REPORT_PATH.format(year=year)}"
         headers = {
             "Authorization": f"Bearer {self._get_token()}",
@@ -59,6 +61,18 @@ class ScientificIndexService:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
         presigned_url = response.json()["uri"]
-        xlsx_response = requests.get(presigned_url)
-        xlsx_response.raise_for_status()
-        return xlsx_response.content
+        return self._poll_for_xlsx(presigned_url, timeout_minutes)
+
+    def _poll_for_xlsx(self, presigned_url: str, timeout_minutes: int) -> bytes:
+        deadline = datetime.now() + timedelta(minutes=timeout_minutes)
+        attempt = 0
+        while datetime.now() < deadline:
+            attempt += 1
+            xlsx_response = requests.get(presigned_url)
+            if xlsx_response.status_code == 200:
+                return xlsx_response.content
+            if xlsx_response.status_code != 404:
+                xlsx_response.raise_for_status()
+            logger.debug("Attempt %d: report not ready, retrying in %ds...", attempt, POLL_INTERVAL_SECONDS)
+            time.sleep(POLL_INTERVAL_SECONDS)
+        raise TimeoutError(f"Report not available after {timeout_minutes} minutes")

--- a/commands/services/scientific_index_api.py
+++ b/commands/services/scientific_index_api.py
@@ -1,19 +1,13 @@
 import boto3
-import io
 import json
 import logging
 import requests
 from datetime import datetime, timedelta
 
-import polars as pl
-from tqdm import tqdm
-
-from commands.services.customers_api import get_all_customers
-
 logger = logging.getLogger(__name__)
 
-XLSX_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-INSTITUTION_REPORT_PATH = "scientific-index/institution-approval-report"
+XLSX_AUTHOR_SHARES_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares"
+ALL_INSTITUTIONS_REPORT_PATH = "scientific-index/reports/{year}/institutions"
 
 
 class ScientificIndexService:
@@ -56,63 +50,12 @@ class ScientificIndexService:
             self.token = self._get_cognito_token()
         return self.token
 
-    def get_institution_report(self, cristin_id: str, year: int) -> bytes:
-        url = f"https://{self.api_domain}/{INSTITUTION_REPORT_PATH}/{year}"
+    def get_all_institutions_report(self, year: int) -> bytes:
+        url = f"https://{self.api_domain}/{ALL_INSTITUTIONS_REPORT_PATH.format(year=year)}"
         headers = {
             "Authorization": f"Bearer {self._get_token()}",
-            "Accept": XLSX_ACCEPT,
+            "Accept": XLSX_AUTHOR_SHARES_ACCEPT,
         }
-        response = requests.get(url, headers=headers, params={"institutionId": cristin_id})
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
         return response.content
-
-    def get_all_institution_reports(self, profile: str, year: int) -> pl.DataFrame:
-        nvi_customers = [
-            customer
-            for customer in get_all_customers(profile)
-            if customer.nvi_institution and customer.cristin_id
-        ]
-
-        if not nvi_customers:
-            raise ValueError("No NVI institutions found")
-
-        logger.info("Found %d NVI institutions. Fetching reports for %d...", len(nvi_customers), year)
-        if not logger.isEnabledFor(logging.DEBUG):
-            logging.getLogger("fastexcel").setLevel(logging.ERROR)
-
-        frames: list[tuple[str, pl.DataFrame]] = []
-        errors: list[str] = []
-
-        for customer in tqdm(nvi_customers, desc="Fetching reports"):
-            cristin_short_id = customer.cristin_id.rsplit("/", 1)[-1]
-            try:
-                data = self.get_institution_report(cristin_short_id, year)
-                df = pl.read_excel(io.BytesIO(data), raise_if_empty=False)
-                if len(df) > 0 and self._has_valid_headers(df):
-                    frames.append((customer.name, df))
-                elif len(df) > 0:
-                    logger.debug("Skipping %s (%s): unexpected column headers %s", customer.name, cristin_short_id, list(df.columns[:3]))
-            except Exception as error:
-                errors.append(f"{customer.name} ({cristin_short_id}): {error}")
-
-        if errors:
-            logger.warning("Failed to fetch %d reports:\n%s", len(errors), "\n".join(f"  {e}" for e in errors))
-
-        if not frames:
-            raise ValueError("No reports fetched successfully")
-
-        self._log_schema_conflicts(frames)
-        return pl.concat([df for _, df in frames], how="diagonal_relaxed")
-
-    def _has_valid_headers(self, df: pl.DataFrame) -> bool:
-        return df.columns[0].isalpha() or "_" in df.columns[0]
-
-    def _log_schema_conflicts(self, frames: list[tuple[str, pl.DataFrame]]) -> None:
-        col_type_map: dict[str, dict[str, list[str]]] = {}
-        for name, df in frames:
-            for col, dtype in df.schema.items():
-                col_type_map.setdefault(col, {}).setdefault(str(dtype), []).append(name)
-        for col, type_map in col_type_map.items():
-            if len(type_map) > 1:
-                details = ", ".join(f"{dtype} ({len(names)} institutions)" for dtype, names in type_map.items())
-                logger.debug("Schema conflict in column '%s': %s", col, details)


### PR DESCRIPTION
Replaces the per-institution local aggregation with a single API call.

- Removes `--institution-id` option and `author-shares-all` command
- Calls `GET /scientific-index/reports/{year}/institutions` with XLSX author-shares Accept header
- Uses existing backend token (client credentials) for authentication

https://sikt.atlassian.net/browse/NP-50985