### PR TITLE
test: Add tests for DLQ and pipeline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ uv run ruff check
 uv run ruff format
 ```
 
+#### Output vs logging in commands
+
+Commands have two channels for text:
+
+* `click.echo(...)` for **command output**: the data the user invoked the command to get (JSON results, identifiers, file paths).
+  Goes to stdout, is unaffected by `--quiet`, and is meant to be piped (`| jq`, `> file.json`).
+* `logger.info(...)` (and `logger.warning`, `logger.error`) for **status and progress messages**: which queue is being read, retry notices, deletion confirmations.
+  Goes through the rich handler to stderr and is suppressed by `--quiet` / amplified by `--verbose`.
+
+A useful test: if you pipe the command into `jq`, the result you assume is fed in is what should go through `click.echo`.
+Everything else is a log line.
+
 ## Usage
 
 Preqrequisites to use this project:

--- a/commands/dlq.py
+++ b/commands/dlq.py
@@ -74,6 +74,7 @@ def read(ctx: AppContext, queue: str, count: int) -> None:
     is_flag=True,
     help="Show what would be deleted without actually deleting",
 )
+@click.pass_obj
 def purge(ctx: AppContext, queue: str, count: int, prefix: str, dry_run: bool) -> None:
     session = boto3.Session(profile_name=ctx.profile)
     sqs_client = session.client("sqs")

--- a/commands/dlq.py
+++ b/commands/dlq.py
@@ -1,5 +1,4 @@
 import click
-import boto3
 import logging
 import json
 from commands.utils import AppContext
@@ -38,14 +37,10 @@ def dlq(
 )
 @click.pass_obj
 def read(ctx: AppContext, queue: str, count: int) -> None:
-    session = boto3.Session(profile_name=ctx.profile)
-    sqs_client = session.client("sqs")
+    sqs_client = ctx.session.client("sqs")
     messages = get_messages(sqs_client, queue, count)
-    by_sender, by_type = summarize_messages(messages)
-    logger.info("Summary of messages by sender:")
-    logger.info(json.dumps(by_sender, indent=2, default=str))
-    logger.info("Summary of messages by body text:")
-    logger.info(json.dumps(by_type, indent=2, default=str))
+    by_sender, by_body = summarize_messages(messages)
+    click.echo(json.dumps({"by_sender": by_sender, "by_body": by_body}, indent=2))
 
 
 @dlq.command(
@@ -76,8 +71,7 @@ def read(ctx: AppContext, queue: str, count: int) -> None:
 )
 @click.pass_obj
 def purge(ctx: AppContext, queue: str, count: int, prefix: str, dry_run: bool) -> None:
-    session = boto3.Session(profile_name=ctx.profile)
-    sqs_client = session.client("sqs")
+    sqs_client = ctx.session.client("sqs")
 
     logger.info(f"Target queue: {queue}")
     logger.info(f"Prefix to match: {prefix}")
@@ -86,12 +80,11 @@ def purge(ctx: AppContext, queue: str, count: int, prefix: str, dry_run: bool) -
     if dry_run:
         messages = get_messages(sqs_client, queue, count)
         to_delete = [msg for msg in messages if msg.get("Body", "").startswith(prefix)]
-        by_sender, by_type = summarize_messages(to_delete)
-        logger.info(f"DRY RUN - Found {len(to_delete)} messages to delete:")
-        logger.info("Summary by sender:")
-        logger.info(by_sender)
-        logger.info("Summary by content:")
-        logger.info(by_type)
+        by_sender, by_body = summarize_messages(to_delete)
+        click.echo(json.dumps(
+            {"matched_count": len(to_delete), "by_sender": by_sender, "by_body": by_body},
+            indent=2,
+        ))
         return
     if not click.confirm("Purge messages from this queue?", default=False):
         logger.info("Aborting...")

--- a/commands/services/dlq.py
+++ b/commands/services/dlq.py
@@ -37,10 +37,10 @@ def get_messages(sqs_client, queue: str, max_count: int) -> list[dict[str, any]]
     return all_messages
 
 
-def summarize_messages(messages: list[dict[str, any]]) -> tuple:
-    """Summarize messages by sender and body."""
+def summarize_messages(messages: list[dict]) -> tuple[dict, dict]:
+    """Summarize messages, grouped by sender and by body. Return JSON-serializable dicts."""
     by_sender = defaultdict(lambda: {"count": 0, "candidates": set()})
-    by_type = defaultdict(lambda: {"count": 0, "candidates": set()})
+    by_body = defaultdict(lambda: {"count": 0, "candidates": set()})
 
     for msg in messages:
         sender_id = msg.get("Attributes", {}).get("SenderId", "Unknown")
@@ -50,14 +50,19 @@ def summarize_messages(messages: list[dict[str, any]]) -> tuple:
             .get("candidateIdentifier", {})
             .get("StringValue", "Unknown")
         )
-
         by_sender[sender_id]["count"] += 1
         by_sender[sender_id]["candidates"].add(candidate)
+        by_body[body]["count"] += 1
+        by_body[body]["candidates"].add(candidate)
 
-        by_type[body]["count"] += 1
-        by_type[body]["candidates"].add(candidate)
+    return _finalize(by_sender), _finalize(by_body)
 
-    return by_sender, by_type
+
+def _finalize(grouped: dict) -> dict:
+    return {
+        key: {"count": value["count"], "candidates": sorted(value["candidates"])}
+        for key, value in grouped.items()
+    }
 
 
 def delete_messages_with_prefix(

--- a/commands/tests/test_cognito_cli.py
+++ b/commands/tests/test_cognito_cli.py
@@ -25,7 +25,7 @@ def test_cognito_search_prints_matching_user_as_json():
 
     result = CliRunner().invoke(cli, ["--quiet", "cognito", "search", "alice"])
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, result.exception
     payload = json.loads(result.output)
     assert payload[0]["Username"] == "alice"
 
@@ -36,5 +36,5 @@ def test_cognito_search_prints_null_when_no_match():
 
     result = CliRunner().invoke(cli, ["--quiet", "cognito", "search", "nobody"])
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, result.exception
     assert json.loads(result.output) is None

--- a/commands/tests/test_dlq_cli.py
+++ b/commands/tests/test_dlq_cli.py
@@ -1,0 +1,54 @@
+import json
+
+import boto3
+from click.testing import CliRunner
+from moto import mock_aws
+
+from cli import cli
+
+
+def _seed_queue(name: str, bodies: list[str]) -> str:
+    sqs = boto3.client("sqs")
+    queue_url = sqs.create_queue(QueueName=name)["QueueUrl"]
+    for body in bodies:
+        sqs.send_message(QueueUrl=queue_url, MessageBody=body)
+    return queue_url
+
+
+@mock_aws
+def test_dlq_read_groups_messages_by_body_with_counts():
+    queue_url = _seed_queue(
+        "nva-test-dlq",
+        ["Failed to migrate doc xyz", "Failed to migrate doc xyz", "Other error"],
+    )
+
+    result = CliRunner().invoke(cli, ["--quiet", "dlq", "read", "--queue", queue_url])
+
+    assert result.exit_code == 0, result.exception
+    summary = json.loads(result.output)
+    assert summary["by_body"]["Failed to migrate doc xyz"]["count"] == 2
+    assert summary["by_body"]["Other error"]["count"] == 1
+
+
+@mock_aws
+def test_dlq_purge_dry_run_reports_matches_and_does_not_delete():
+    queue_url = _seed_queue(
+        "nva-test-dlq",
+        ["DocumentNotFound: 1", "DocumentNotFound: 2", "OtherError: 3"],
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--quiet", "dlq", "purge", "--queue", queue_url, "--prefix", "DocumentNotFound", "--dry-run"]
+    )
+
+    assert result.exit_code == 0, result.exception
+    report = json.loads(result.output)
+    assert report["matched_count"] == 2
+
+    attributes = boto3.client("sqs").get_queue_attributes(
+        QueueUrl=queue_url,
+        AttributeNames=["ApproximateNumberOfMessages", "ApproximateNumberOfMessagesNotVisible"],
+    )["Attributes"]
+    visible = int(attributes["ApproximateNumberOfMessages"])
+    in_flight = int(attributes["ApproximateNumberOfMessagesNotVisible"])
+    assert visible + in_flight == 3

--- a/commands/tests/test_pipelines_cli.py
+++ b/commands/tests/test_pipelines_cli.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+import boto3
+from click.testing import CliRunner
+from moto import mock_aws
+
+from cli import cli
+
+
+def _build_session_with_stubbed_codepipeline(fake_codepipeline) -> boto3.Session:
+    session = boto3.Session()
+    real_client = session.client
+    session.client = lambda name, *args, **kwargs: (
+        fake_codepipeline if name == "codepipeline" else real_client(name, *args, **kwargs)
+    )
+    return session
+
+
+@mock_aws
+def test_pipelines_branches_renders_pipeline_with_source_details():
+    boto3.client("iam").create_account_alias(AccountAlias="nva-test")
+    fake_codepipeline = MagicMock()
+    fake_codepipeline.list_pipelines.return_value = {"pipelines": [{"name": "test-pipeline"}]}
+    fake_codepipeline.get_pipeline_state.return_value = {
+        "stageStates": [
+            {
+                "stageName": "Source",
+                "actionStates": [
+                    {"entityUrl": "https://example.org/?Branch=develop&FullRepositoryId=org/repo"}
+                ],
+            }
+        ]
+    }
+    fake_codepipeline.list_pipeline_executions.return_value = {"pipelineExecutionSummaries": []}
+
+    with patch("cli.build_session", return_value=_build_session_with_stubbed_codepipeline(fake_codepipeline)):
+        result = CliRunner().invoke(cli, ["--quiet", "pipelines", "branches"])
+
+    assert result.exit_code == 0, result.exception
+    assert "org/repo" in result.output
+    assert "develop" in result.output
+    assert "nva-test" in result.output
+
+
+@mock_aws
+def test_pipelines_branches_skips_pipelines_without_source_details():
+    boto3.client("iam").create_account_alias(AccountAlias="nva-test")
+    fake_codepipeline = MagicMock()
+    fake_codepipeline.list_pipelines.return_value = {"pipelines": [{"name": "irrelevant"}]}
+    fake_codepipeline.get_pipeline_state.return_value = {
+        "stageStates": [{"stageName": "Source", "actionStates": [{"entityUrl": ""}]}]
+    }
+    fake_codepipeline.list_pipeline_executions.return_value = {"pipelineExecutionSummaries": []}
+
+    with patch("cli.build_session", return_value=_build_session_with_stubbed_codepipeline(fake_codepipeline)):
+        result = CliRunner().invoke(cli, ["--quiet", "pipelines", "branches"])
+
+    assert result.exit_code == 0, result.exception
+    assert "irrelevant" not in result.output
+    assert "0 pipelines" in result.output


### PR DESCRIPTION
Changes:

- [fix(dlq): add missing @click.pass_obj on purge command](https://github.com/BIBSYSDEV/nva-aws-cli-tools/pull/58/commits/55df13f54ece071cb52a41a65a2d813bd49428a5)
- [refactor(dlq): emit results via click.echo, return JSON-friendly summaries](https://github.com/BIBSYSDEV/nva-aws-cli-tools/pull/58/commits/28588007bf222989aedaf6329d872f977cd422ce)
- [test: add CLI integration tests for dlq, pipelines, and switch assert idiom](https://github.com/BIBSYSDEV/nva-aws-cli-tools/pull/58/commits/ca6464f205d77a8628de2181412b4650b9306cf1)
- [docs: clarify click.echo vs logger.info convention](https://github.com/BIBSYSDEV/nva-aws-cli-tools/pull/58/commits/5dcc95ef17ff3e5e055f5c114d16acb3af41ac12)
