### PR TITLE
feat(s3): add get-versions command to download S3 object version history as git commits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -18,6 +18,7 @@ from commands.search import search
 from commands.reports import reports
 from commands.sws import sws
 from commands.services.aws_utils import build_session
+from commands.s3 import s3
 from commands.utils import AppContext
 
 from log_config import configure_logger
@@ -65,6 +66,7 @@ cli.add_command(sqs)
 cli.add_command(search)
 cli.add_command(reports)
 cli.add_command(sws)
+cli.add_command(s3)
 
 if __name__ == "__main__":
     cli()

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -2,7 +2,11 @@ import click
 import logging
 
 from commands.utils import AppContext
-from commands.services.s3_versions import download_versions, build_git_history
+from commands.services.s3_versions import (
+    download_versions,
+    build_git_history,
+    _tracked_filename_for_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +15,6 @@ logger = logging.getLogger(__name__)
 @click.pass_obj
 def s3(ctx: AppContext):
     """S3 utilities."""
-    pass
 
 
 @s3.command(
@@ -44,9 +47,17 @@ def get_versions(
 
     s3_client = ctx.session.client("s3")
 
-    version_dir = download_versions(s3_client, bucket, object_path, output_dir)
+    try:
+        version_dir = download_versions(s3_client, bucket, object_path, output_dir)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+
     click.echo(f"Versions saved to: {version_dir}")
 
     if not no_git:
-        build_git_history(version_dir)
+        tracked_filename = _tracked_filename_for_key(object_path)
+        try:
+            build_git_history(version_dir, tracked_filename)
+        except RuntimeError as exc:
+            raise click.ClickException(f"Git error: {exc}")
         click.echo(f"Git history created in: {version_dir}")

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -5,7 +5,6 @@ from commands.utils import AppContext
 from commands.services.s3_versions import (
     download_versions,
     build_git_history,
-    _tracked_filename_for_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,9 +54,8 @@ def get_versions(
     click.echo(f"Versions saved to: {version_dir}")
 
     if not no_git:
-        tracked_filename = _tracked_filename_for_key(object_path)
         try:
-            build_git_history(version_dir, tracked_filename)
+            build_git_history(version_dir, object_path)
         except RuntimeError as exc:
             raise click.ClickException(f"Git error: {exc}")
         click.echo(f"Git history created in: {version_dir}")

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -1,0 +1,54 @@
+import click
+import boto3
+import logging
+
+from commands.utils import AppContext
+from commands.services.s3_versions import download_versions, build_git_history
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+@click.pass_obj
+def s3(ctx: AppContext):
+    """S3 utilities."""
+    pass
+
+
+@s3.command(
+    help="Download all versions of an S3 object and create a git history.\n\n"
+    "S3_PATH is bucket/key, e.g. 'persisted-resources-755923822223/resources/0198cc877130-....gz'."
+)
+@click.argument("s3_path")
+@click.option(
+    "-o",
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Base directory where the version folder is created",
+)
+@click.option(
+    "--no-git",
+    is_flag=True,
+    help="Skip git history creation",
+)
+@click.pass_obj
+def get_versions(
+    ctx: AppContext,
+    s3_path: str,
+    output_dir: str,
+    no_git: bool,
+) -> None:
+    bucket, _, object_path = s3_path.partition("/")
+    if not object_path:
+        raise click.BadParameter("S3_PATH must be bucket/key", param_hint="S3_PATH")
+
+    session = boto3.Session(profile_name=ctx.profile)
+    s3_client = session.client("s3")
+
+    version_dir = download_versions(s3_client, bucket, object_path, output_dir)
+    click.echo(f"Versions saved to: {version_dir}")
+
+    if not no_git:
+        build_git_history(version_dir)
+        click.echo(f"Git history created in: {version_dir}")

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -5,9 +5,13 @@ from commands.utils import AppContext
 from commands.services.s3_versions import (
     download_versions,
     build_git_history,
+    find_bucket,
 )
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_BUCKET_SUBSTRING = "persisted-resources"
+DEFAULT_PREFIX = "resources/"
 
 
 @click.group()
@@ -16,11 +20,20 @@ def s3(ctx: AppContext):
     """S3 utilities."""
 
 
-@s3.command(
-    help="Download all versions of an S3 object and create a git history.\n\n"
-    "S3_PATH is bucket/key, e.g. 'persisted-resources-755923822223/resources/0198cc877130-....gz'."
+@s3.command()
+@click.argument("object_key")
+@click.option(
+    "--bucket",
+    default=DEFAULT_BUCKET_SUBSTRING,
+    show_default=True,
+    help="Substring of the bucket name to match",
 )
-@click.argument("s3_path")
+@click.option(
+    "--prefix",
+    default=DEFAULT_PREFIX,
+    show_default=True,
+    help="Key prefix prepended to OBJECT_KEY",
+)
 @click.option(
     "-o",
     "--output-dir",
@@ -36,18 +49,76 @@ def s3(ctx: AppContext):
 @click.pass_obj
 def get_versions(
     ctx: AppContext,
-    s3_path: str,
+    object_key: str,
+    bucket: str,
+    prefix: str,
     output_dir: str,
     no_git: bool,
 ) -> None:
-    bucket, _, object_path = s3_path.partition("/")
-    if not object_path:
-        raise click.BadParameter("S3_PATH must be bucket/key", param_hint="S3_PATH")
+    """Download all versions of an S3 object and create a git history.
 
+    Resolves OBJECT_KEY to s3://<bucket matching BUCKET>/<PREFIX><OBJECT_KEY>.
+    Useful for the common case of inspecting expanded publications.
+
+    Example:
+      s3 get-versions 0198cc877130-63254c68-0000-0000-0000-000000000000.gz
+    """
     s3_client = ctx.session.client("s3")
 
     try:
-        version_dir = download_versions(s3_client, bucket, object_path, output_dir)
+        resolved_bucket = find_bucket(s3_client, bucket)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+
+    key = prefix.rstrip("/") + "/" + object_key.lstrip("/")
+    _fetch_and_build(s3_client, resolved_bucket, key, output_dir, no_git)
+
+
+@s3.command()
+@click.argument("s3_uri")
+@click.option(
+    "-o",
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Base directory where the version folder is created",
+)
+@click.option(
+    "--no-git",
+    is_flag=True,
+    help="Skip git history creation",
+)
+@click.pass_obj
+def get_versions_uri(
+    ctx: AppContext,
+    s3_uri: str,
+    output_dir: str,
+    no_git: bool,
+) -> None:
+    """Download all versions using a full S3 URI.
+
+    S3_URI accepts s3://bucket/key or bucket/key.
+
+    Example:
+      s3 get-versions-uri persisted-resources-755923822223/resources/0198cc877130-....gz
+      s3 get-versions-uri s3://persisted-resources-755923822223/resources/0198cc877130-....gz
+    """
+    uri = s3_uri.removeprefix("s3://")
+    bucket, _, object_path = uri.partition("/")
+    if not object_path:
+        raise click.BadParameter(
+            "S3_URI must be bucket/key or s3://bucket/key", param_hint="S3_URI"
+        )
+
+    s3_client = ctx.session.client("s3")
+    _fetch_and_build(s3_client, bucket, object_path, output_dir, no_git)
+
+
+def _fetch_and_build(
+    s3_client, bucket: str, key: str, output_dir: str, no_git: bool
+) -> None:
+    try:
+        version_dir = download_versions(s3_client, bucket, key, output_dir)
     except ValueError as exc:
         raise click.ClickException(str(exc))
 
@@ -55,7 +126,7 @@ def get_versions(
 
     if not no_git:
         try:
-            build_git_history(version_dir, object_path)
+            build_git_history(version_dir, key)
         except RuntimeError as exc:
             raise click.ClickException(f"Git error: {exc}")
         click.echo(f"Git history created in: {version_dir}")

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -64,15 +64,15 @@ def get_versions(
       s3 get-versions 0198cc877130-63254c68-0000-0000-0000-000000000000.gz
     """
     s3_client = ctx.session.client("s3")
-
     try:
         resolved_bucket = find_bucket(s3_client, bucket)
+        normalized_key = (
+            object_key if object_key.endswith(".gz") else f"{object_key}.gz"
+        )
+        key = prefix.rstrip("/") + "/" + normalized_key.lstrip("/")
+        _fetch_and_build(s3_client, resolved_bucket, key, output_dir, no_git)
     except ValueError as exc:
         raise click.ClickException(str(exc))
-
-    normalized_key = object_key if object_key.endswith(".gz") else f"{object_key}.gz"
-    key = prefix.rstrip("/") + "/" + normalized_key.lstrip("/")
-    _fetch_and_build(s3_client, resolved_bucket, key, output_dir, no_git)
 
 
 @s3.command()
@@ -112,16 +112,16 @@ def get_versions_uri(
         )
 
     s3_client = ctx.session.client("s3")
-    _fetch_and_build(s3_client, bucket, object_path, output_dir, no_git)
+    try:
+        _fetch_and_build(s3_client, bucket, object_path, output_dir, no_git)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
 
 
 def _fetch_and_build(
     s3_client, bucket: str, key: str, output_dir: str, no_git: bool
 ) -> None:
-    try:
-        version_dir = download_versions(s3_client, bucket, key, output_dir)
-    except ValueError as exc:
-        raise click.ClickException(str(exc))
+    version_dir = download_versions(s3_client, bucket, key, output_dir)
 
     click.echo(f"Versions saved to: {version_dir}")
 

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -1,5 +1,4 @@
 import click
-import boto3
 import logging
 
 from commands.utils import AppContext
@@ -43,8 +42,7 @@ def get_versions(
     if not object_path:
         raise click.BadParameter("S3_PATH must be bucket/key", param_hint="S3_PATH")
 
-    session = boto3.Session(profile_name=ctx.profile)
-    s3_client = session.client("s3")
+    s3_client = ctx.session.client("s3")
 
     version_dir = download_versions(s3_client, bucket, object_path, output_dir)
     click.echo(f"Versions saved to: {version_dir}")

--- a/commands/s3.py
+++ b/commands/s3.py
@@ -70,7 +70,8 @@ def get_versions(
     except ValueError as exc:
         raise click.ClickException(str(exc))
 
-    key = prefix.rstrip("/") + "/" + object_key.lstrip("/")
+    normalized_key = object_key if object_key.endswith(".gz") else f"{object_key}.gz"
+    key = prefix.rstrip("/") + "/" + normalized_key.lstrip("/")
     _fetch_and_build(s3_client, resolved_bucket, key, output_dir, no_git)
 
 

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -45,6 +45,16 @@ def _tracked_filename_for_key(key: str) -> str:
     return name
 
 
+def find_bucket(s3_client: Any, name_substring: str) -> str:
+    response = s3_client.list_buckets()
+    matches = [b["Name"] for b in response["Buckets"] if name_substring in b["Name"]]
+    if not matches:
+        raise ValueError(f"No bucket found matching '{name_substring}'")
+    if len(matches) > 1:
+        raise ValueError(f"Multiple buckets match '{name_substring}': {matches}")
+    return matches[0]
+
+
 def fetch_versions(s3_client: Any, bucket: str, key: str) -> list[dict]:
     versions = []
     paginator = s3_client.get_paginator("list_object_versions")

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 ILLEGAL_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
 
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
 def sanitize_to_folder_name(path: str) -> str:
     return ILLEGAL_CHARS.sub("_", path).strip("_")
 
@@ -31,7 +35,7 @@ def decompress_if_needed(data: bytes, key: str) -> bytes:
         try:
             return gzip.decompress(data)
         except Exception as exc:
-            logger.warning(f"Failed to decompress gz data: {exc}")
+            logger.warning("Failed to decompress gz data: %s", exc)
     return data
 
 
@@ -50,7 +54,7 @@ def download_versions(
     output_base: str,
 ) -> Path:
     key = object_path.lstrip("/")  # tolerate a leading slash from the user
-    folder_name = sanitize_to_folder_name(object_path)
+    folder_name = sanitize_to_folder_name(key)
     output_dir = Path(output_base) / folder_name
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -58,7 +62,7 @@ def download_versions(
     if not versions:
         raise ValueError(f"No versions found for '{key}' in bucket '{bucket}'")
 
-    logger.info(f"Found {len(versions)} versions in s3://{bucket}/{key}")
+    logger.info("Found %d versions in s3://%s/%s", len(versions), bucket, key)
 
     for version in versions:
         version_id = version["VersionId"]
@@ -68,7 +72,7 @@ def download_versions(
         filepath = output_dir / filename
 
         if filepath.exists():
-            logger.info(f"Skipping (already exists): {filename}")
+            logger.info("Skipping (already exists): %s", filename)
             continue
 
         response = s3_client.get_object(Bucket=bucket, Key=key, VersionId=version_id)
@@ -76,7 +80,7 @@ def download_versions(
         data = decompress_if_needed(raw, key)
         data = try_pretty_json(data)
         filepath.write_bytes(data)
-        logger.info(f"Downloaded: {filename}")
+        logger.info("Downloaded: %s", filename)
 
     return output_dir
 
@@ -87,12 +91,12 @@ def build_git_history(output_dir: Path) -> None:
         logger.info("Git repo already exists, skipping git history creation")
         return
 
-    subprocess.run(["git", "init"], cwd=output_dir, check=True)
+    _git(output_dir, "init")
     # Only track object.json — each commit overwrites it with one version so `git diff` shows changes between versions.
     # The raw version files stay on disk for reference but are intentionally excluded from git.
     (output_dir / ".gitignore").write_text("*\n!object.json\n!.gitignore\n")
-    subprocess.run(["git", "add", ".gitignore"], cwd=output_dir, check=True)
-    subprocess.run(["git", "commit", "-m", "init"], cwd=output_dir, check=True)
+    _git(output_dir, "add", ".gitignore")
+    _git(output_dir, "commit", "-m", "init")
 
     version_files = sorted(
         f for f in output_dir.iterdir() if f.is_file() and not f.name.startswith(".")
@@ -101,13 +105,7 @@ def build_git_history(output_dir: Path) -> None:
     object_file = output_dir / "object.json"
     for filepath in version_files:
         object_file.write_bytes(filepath.read_bytes())
-        subprocess.run(["git", "add", "object.json"], cwd=output_dir, check=True)
-        subprocess.run(
-            ["git", "commit", "--allow-empty", "-m", filepath.name],
-            cwd=output_dir,
-            check=True,
-        )
+        _git(output_dir, "add", "object.json")
+        _git(output_dir, "commit", "--allow-empty", "-m", filepath.name)
 
-    logger.info(
-        f"Git history created with {len(version_files)} commits in {output_dir}"
-    )
+    logger.info("Git history created with %d commits in %s", len(version_files), output_dir)

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -1,0 +1,109 @@
+import boto3
+import gzip
+import json
+import re
+import subprocess
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ILLEGAL_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_to_folder_name(path: str) -> str:
+    return ILLEGAL_CHARS.sub("_", path).strip("_")
+
+
+def fetch_versions(s3_client, bucket: str, key: str) -> list[dict]:
+    versions = []
+    paginator = s3_client.get_paginator("list_object_versions")
+    for page in paginator.paginate(Bucket=bucket, Prefix=key):
+        for version in page.get("Versions", []):
+            if version["Key"] == key:
+                versions.append(version)
+    versions.sort(key=lambda v: v["LastModified"])
+    return versions
+
+
+def decompress_if_needed(data: bytes, key: str) -> bytes:
+    if key.endswith(".gz"):
+        try:
+            return gzip.decompress(data)
+        except Exception as exc:
+            logger.warning(f"Failed to decompress gz data: {exc}")
+    return data
+
+
+def try_pretty_json(data: bytes) -> bytes:
+    try:
+        parsed = json.loads(data)
+        return json.dumps(parsed, indent=2, ensure_ascii=False).encode("utf-8")
+    except Exception:
+        return data
+
+
+def download_versions(
+    s3_client,
+    bucket: str,
+    object_path: str,
+    output_base: str,
+) -> Path:
+    key = object_path.lstrip("/")  # tolerate a leading slash from the user
+    folder_name = sanitize_to_folder_name(object_path)
+    output_dir = Path(output_base) / folder_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    versions = fetch_versions(s3_client, bucket, key)
+    if not versions:
+        raise ValueError(f"No versions found for '{key}' in bucket '{bucket}'")
+
+    logger.info(f"Found {len(versions)} versions in s3://{bucket}/{key}")
+
+    for version in versions:
+        version_id = version["VersionId"]
+        last_modified = version["LastModified"]
+        date_prefix = last_modified.strftime("%Y%m%d_%H%M%S")
+        filename = f"{date_prefix}_{version_id}"
+        filepath = output_dir / filename
+
+        if filepath.exists():
+            logger.info(f"Skipping (already exists): {filename}")
+            continue
+
+        response = s3_client.get_object(Bucket=bucket, Key=key, VersionId=version_id)
+        raw = response["Body"].read()
+        data = decompress_if_needed(raw, key)
+        data = try_pretty_json(data)
+        filepath.write_bytes(data)
+        logger.info(f"Downloaded: {filename}")
+
+    return output_dir
+
+
+def build_git_history(output_dir: Path) -> None:
+    git_dir = output_dir / ".git"
+    if git_dir.exists():
+        logger.info("Git repo already exists, skipping git history creation")
+        return
+
+    subprocess.run(["git", "init"], cwd=output_dir, check=True)
+    (output_dir / ".gitignore").write_text("*\n!object.json\n!.gitignore\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=output_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=output_dir, check=True)
+
+    version_files = sorted(
+        f for f in output_dir.iterdir() if f.is_file() and not f.name.startswith(".")
+    )
+
+    object_file = output_dir / "object.json"
+    for filepath in version_files:
+        object_file.write_bytes(filepath.read_bytes())
+        subprocess.run(["git", "add", "object.json"], cwd=output_dir, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", filepath.name],
+            cwd=output_dir,
+            check=True,
+        )
+
+    logger.info(f"Git history created with {len(version_files)} commits in {output_dir}")

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -1,4 +1,3 @@
-import boto3
 import gzip
 import json
 import re

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -70,7 +70,7 @@ def decompress_if_needed(data: bytes, key: str) -> bytes:
     if key.endswith(".gz"):
         try:
             return gzip.decompress(data)
-        except Exception as exc:
+        except (gzip.BadGzipFile, OSError) as exc:
             logger.warning("Failed to decompress gz data: %s", exc)
     return data
 
@@ -79,7 +79,7 @@ def try_pretty_json(data: bytes) -> bytes:
     try:
         parsed = json.loads(data)
         return json.dumps(parsed, indent=2, ensure_ascii=False).encode("utf-8")
-    except Exception:
+    except json.JSONDecodeError:
         return data
 
 

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import logging
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ def sanitize_to_folder_name(path: str) -> str:
     return ILLEGAL_CHARS.sub("_", path).strip("_")
 
 
-def fetch_versions(s3_client, bucket: str, key: str) -> list[dict]:
+def fetch_versions(s3_client: Any, bucket: str, key: str) -> list[dict]:
     versions = []
     paginator = s3_client.get_paginator("list_object_versions")
     for page in paginator.paginate(Bucket=bucket, Prefix=key):
@@ -43,7 +44,7 @@ def try_pretty_json(data: bytes) -> bytes:
 
 
 def download_versions(
-    s3_client,
+    s3_client: Any,
     bucket: str,
     object_path: str,
     output_base: str,
@@ -87,6 +88,8 @@ def build_git_history(output_dir: Path) -> None:
         return
 
     subprocess.run(["git", "init"], cwd=output_dir, check=True)
+    # Only track object.json — each commit overwrites it with one version so `git diff` shows changes between versions.
+    # The raw version files stay on disk for reference but are intentionally excluded from git.
     (output_dir / ".gitignore").write_text("*\n!object.json\n!.gitignore\n")
     subprocess.run(["git", "add", ".gitignore"], cwd=output_dir, check=True)
     subprocess.run(["git", "commit", "-m", "init"], cwd=output_dir, check=True)

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -111,10 +111,14 @@ def download_versions(
     return output_dir
 
 
-def build_git_history(output_dir: Path, tracked_filename: str = "object.json") -> None:
+def build_git_history(output_dir: Path, key: str = "") -> None:
+    tracked_filename = _tracked_filename_for_key(key) if key else "object.json"
     git_dir = output_dir / ".git"
     if git_dir.exists():
-        logger.info("Git repo already exists, skipping git history creation")
+        logger.warning(
+            "Git repo already exists in %s — skipping. Delete the .git folder to rebuild.",
+            output_dir,
+        )
         return
 
     _git(output_dir, "init")

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -108,4 +108,6 @@ def build_git_history(output_dir: Path) -> None:
             check=True,
         )
 
-    logger.info(f"Git history created with {len(version_files)} commits in {output_dir}")
+    logger.info(
+        f"Git history created with {len(version_files)} commits in {output_dir}"
+    )

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import os
 import re
 import subprocess
 import logging
@@ -10,13 +11,38 @@ logger = logging.getLogger(__name__)
 
 ILLEGAL_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
+_GIT_IDENTITY_DEFAULTS = {
+    "GIT_AUTHOR_NAME": "nva-aws-cli-tools",
+    "GIT_AUTHOR_EMAIL": "nva-aws-cli-tools@local",
+    "GIT_COMMITTER_NAME": "nva-aws-cli-tools",
+    "GIT_COMMITTER_EMAIL": "nva-aws-cli-tools@local",
+}
+
 
 def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+    env = {
+        **os.environ,
+        **{k: v for k, v in _GIT_IDENTITY_DEFAULTS.items() if k not in os.environ},
+    }
+    try:
+        subprocess.run(
+            ["git", *args], cwd=cwd, check=True, capture_output=True, env=env
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(exc.stderr.decode(errors="replace").strip()) from exc
 
 
 def sanitize_to_folder_name(path: str) -> str:
     return ILLEGAL_CHARS.sub("_", path).strip("_")
+
+
+def _tracked_filename_for_key(key: str) -> str:
+    name = Path(key).name
+    if name.endswith(".gz"):
+        name = name[:-3]
+    if "." not in name:
+        name = f"{name}.json"
+    return name
 
 
 def fetch_versions(s3_client: Any, bucket: str, key: str) -> list[dict]:
@@ -85,16 +111,16 @@ def download_versions(
     return output_dir
 
 
-def build_git_history(output_dir: Path) -> None:
+def build_git_history(output_dir: Path, tracked_filename: str = "object.json") -> None:
     git_dir = output_dir / ".git"
     if git_dir.exists():
         logger.info("Git repo already exists, skipping git history creation")
         return
 
     _git(output_dir, "init")
-    # Only track object.json — each commit overwrites it with one version so `git diff` shows changes between versions.
+    # Only track the single object file — each commit overwrites it with one version so `git diff` shows changes between versions.
     # The raw version files stay on disk for reference but are intentionally excluded from git.
-    (output_dir / ".gitignore").write_text("*\n!object.json\n!.gitignore\n")
+    (output_dir / ".gitignore").write_text(f"*\n!{tracked_filename}\n!.gitignore\n")
     _git(output_dir, "add", ".gitignore")
     _git(output_dir, "commit", "-m", "init")
 
@@ -102,11 +128,11 @@ def build_git_history(output_dir: Path) -> None:
         f for f in output_dir.iterdir() if f.is_file() and not f.name.startswith(".")
     )
 
-    object_file = output_dir / "object.json"
+    object_file = output_dir / tracked_filename
     for filepath in version_files:
         object_file.write_bytes(filepath.read_bytes())
-        _git(output_dir, "add", "object.json")
-        _git(output_dir, "commit", "--allow-empty", "-m", filepath.name)
+        _git(output_dir, "add", tracked_filename)
+        _git(output_dir, "commit", "-m", filepath.name)
 
     logger.info(
         "Git history created with %d commits in %s", len(version_files), output_dir

--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -108,4 +108,6 @@ def build_git_history(output_dir: Path) -> None:
         _git(output_dir, "add", "object.json")
         _git(output_dir, "commit", "--allow-empty", "-m", filepath.name)
 
-    logger.info("Git history created with %d commits in %s", len(version_files), output_dir)
+    logger.info(
+        "Git history created with %d commits in %s", len(version_files), output_dir
+    )

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -5,13 +5,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import boto3
 import pytest
+from click.testing import CliRunner
+from moto import mock_aws
 
+from commands.s3 import s3
 from commands.services.s3_versions import (
     build_git_history,
     decompress_if_needed,
     download_versions,
     fetch_versions,
+    find_bucket,
     sanitize_to_folder_name,
     try_pretty_json,
 )
@@ -222,3 +227,101 @@ def test_build_git_history_skips_if_git_exists(tmp_path: Path):
     with patch("commands.services.s3_versions.subprocess.run") as mock_run:
         build_git_history(version_dir)
         mock_run.assert_not_called()
+
+
+def test_find_bucket_returns_matching_bucket():
+    s3_client = MagicMock()
+    s3_client.list_buckets.return_value = {
+        "Buckets": [
+            {"Name": "persisted-resources-123456789"},
+            {"Name": "other-bucket"},
+        ]
+    }
+    assert find_bucket(s3_client, "persisted-resources") == "persisted-resources-123456789"
+
+
+def test_find_bucket_raises_when_no_match():
+    s3_client = MagicMock()
+    s3_client.list_buckets.return_value = {"Buckets": [{"Name": "other-bucket"}]}
+    with pytest.raises(ValueError, match="No bucket found"):
+        find_bucket(s3_client, "persisted-resources")
+
+
+def test_find_bucket_raises_on_multiple_matches():
+    s3_client = MagicMock()
+    s3_client.list_buckets.return_value = {
+        "Buckets": [
+            {"Name": "persisted-resources-111"},
+            {"Name": "persisted-resources-222"},
+        ]
+    }
+    with pytest.raises(ValueError, match="Multiple buckets"):
+        find_bucket(s3_client, "persisted-resources")
+
+
+def _s3_ctx():
+    from commands.utils import AppContext
+
+    return AppContext(
+        log_level=0, profile=None, session=boto3.Session(region_name="eu-west-1")
+    )
+
+
+@mock_aws
+def test_get_versions_command_resolves_bucket_and_key(tmp_path: Path):
+    boto3_session = boto3.Session(region_name="eu-west-1")
+    s3_client = boto3_session.client("s3", region_name="eu-west-1")
+    bucket_name = "persisted-resources-123456789"
+    s3_client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+    s3_client.put_bucket_versioning(
+        Bucket=bucket_name,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+    content = json.dumps({"id": "abc"}).encode()
+    s3_client.put_object(Bucket=bucket_name, Key="resources/obj.json", Body=content)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            s3,
+            ["get-versions", "obj.json", "--bucket", "persisted-resources", "--no-git"],
+            obj=_s3_ctx(),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Versions saved to" in result.output
+
+
+@mock_aws
+def test_get_versions_uri_command_accepts_s3_prefix(tmp_path: Path):
+    boto3_session = boto3.Session(region_name="eu-west-1")
+    s3_client = boto3_session.client("s3", region_name="eu-west-1")
+    bucket_name = "persisted-resources-123456789"
+    s3_client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+    s3_client.put_bucket_versioning(
+        Bucket=bucket_name,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+    content = json.dumps({"id": "abc"}).encode()
+    s3_client.put_object(Bucket=bucket_name, Key="resources/obj.json", Body=content)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            s3,
+            [
+                "get-versions-uri",
+                f"s3://{bucket_name}/resources/obj.json",
+                "--no-git",
+            ],
+            obj=_s3_ctx(),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Versions saved to" in result.output

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -237,7 +237,9 @@ def test_find_bucket_returns_matching_bucket():
             {"Name": "other-bucket"},
         ]
     }
-    assert find_bucket(s3_client, "persisted-resources") == "persisted-resources-123456789"
+    assert (
+        find_bucket(s3_client, "persisted-resources") == "persisted-resources-123456789"
+    )
 
 
 def test_find_bucket_raises_when_no_match():

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -283,13 +283,13 @@ def test_get_versions_command_resolves_bucket_and_key(tmp_path: Path):
         VersioningConfiguration={"Status": "Enabled"},
     )
     content = json.dumps({"id": "abc"}).encode()
-    s3_client.put_object(Bucket=bucket_name, Key="resources/obj.json", Body=content)
+    s3_client.put_object(Bucket=bucket_name, Key="resources/obj.gz", Body=content)
 
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             s3,
-            ["get-versions", "obj.json", "--bucket", "persisted-resources", "--no-git"],
+            ["get-versions", "obj", "--bucket", "persisted-resources", "--no-git"],
             obj=_s3_ctx(),
         )
 

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -1,0 +1,201 @@
+import gzip
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from commands.services.s3_versions import (
+    build_git_history,
+    decompress_if_needed,
+    download_versions,
+    fetch_versions,
+    sanitize_to_folder_name,
+    try_pretty_json,
+)
+
+
+def test_sanitize_to_folder_name_replaces_slashes():
+    assert sanitize_to_folder_name("bucket/some/key") == "bucket_some_key"
+
+
+def test_sanitize_to_folder_name_replaces_dots():
+    assert sanitize_to_folder_name("file.name.gz") == "file_name_gz"
+
+
+def test_sanitize_to_folder_name_keeps_alphanumeric_and_dash():
+    assert sanitize_to_folder_name("my-key_123") == "my-key_123"
+
+
+def test_sanitize_to_folder_name_strips_leading_trailing_underscores():
+    assert sanitize_to_folder_name("/leading/trailing/") == "leading_trailing"
+
+
+def test_decompress_if_needed_decompresses_gz():
+    original = b"hello world"
+    compressed = gzip.compress(original)
+    result = decompress_if_needed(compressed, "file.gz")
+    assert result == original
+
+
+def test_decompress_if_needed_returns_data_unchanged_for_non_gz():
+    data = b"plain data"
+    result = decompress_if_needed(data, "file.json")
+    assert result == data
+
+
+def test_decompress_if_needed_returns_raw_on_corrupt_gz(caplog):
+    corrupt = b"not gzip data"
+    result = decompress_if_needed(corrupt, "file.gz")
+    assert result == corrupt
+
+
+def test_try_pretty_json_formats_valid_json():
+    raw = b'{"b":2,"a":1}'
+    result = try_pretty_json(raw)
+    parsed = json.loads(result)
+    assert parsed == {"a": 1, "b": 2}
+    assert b"\n" in result
+
+
+def test_try_pretty_json_returns_original_on_invalid_json():
+    raw = b"not json"
+    result = try_pretty_json(raw)
+    assert result == raw
+
+
+def make_version(version_id: str, last_modified: datetime, key: str = "resources/obj.gz") -> dict:
+    return {
+        "Key": key,
+        "VersionId": version_id,
+        "LastModified": last_modified,
+    }
+
+
+def test_fetch_versions_returns_sorted_versions():
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+
+    v1 = make_version("v1", datetime(2024, 1, 1, tzinfo=timezone.utc))
+    v2 = make_version("v2", datetime(2024, 1, 3, tzinfo=timezone.utc))
+    v3 = make_version("v3", datetime(2024, 1, 2, tzinfo=timezone.utc))
+
+    paginator.paginate.return_value = [{"Versions": [v2, v3, v1]}]
+
+    versions = fetch_versions(s3_client, "my-bucket", "resources/obj.gz")
+
+    assert [v["VersionId"] for v in versions] == ["v1", "v3", "v2"]
+
+
+def test_fetch_versions_filters_by_exact_key():
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+
+    target = make_version("v1", datetime(2024, 1, 1, tzinfo=timezone.utc), key="resources/obj.gz")
+    other = make_version("v2", datetime(2024, 1, 2, tzinfo=timezone.utc), key="resources/obj-other.gz")
+
+    paginator.paginate.return_value = [{"Versions": [target, other]}]
+
+    versions = fetch_versions(s3_client, "my-bucket", "resources/obj.gz")
+
+    assert len(versions) == 1
+    assert versions[0]["VersionId"] == "v1"
+
+
+def test_download_versions_creates_files(tmp_path: Path):
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+
+    content = json.dumps({"id": "abc"}).encode()
+    version = make_version("abc123", datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc), key="resources/obj.json")
+    paginator.paginate.return_value = [{"Versions": [version]}]
+    s3_client.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=content))}
+
+    output_dir = download_versions(s3_client, "my-bucket", "resources/obj.json", str(tmp_path))
+
+    files = list(output_dir.iterdir())
+    assert len(files) == 1
+    assert json.loads(files[0].read_bytes()) == {"id": "abc"}
+
+
+def test_download_versions_decompresses_gz(tmp_path: Path):
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+
+    original = {"id": "compressed"}
+    compressed = gzip.compress(json.dumps(original).encode())
+    version = make_version("v1", datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
+    paginator.paginate.return_value = [{"Versions": [version]}]
+    s3_client.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=compressed))}
+
+    output_dir = download_versions(s3_client, "my-bucket", "resources/obj.gz", str(tmp_path))
+
+    files = list(output_dir.iterdir())
+    assert len(files) == 1
+    assert json.loads(files[0].read_bytes()) == original
+
+
+def test_download_versions_raises_when_no_versions(tmp_path: Path):
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+    paginator.paginate.return_value = [{"Versions": []}]
+
+    with pytest.raises(ValueError, match="No versions found"):
+        download_versions(s3_client, "my-bucket", "resources/obj.gz", str(tmp_path))
+
+
+def test_download_versions_skips_existing_files(tmp_path: Path):
+    s3_client = MagicMock()
+    paginator = MagicMock()
+    s3_client.get_paginator.return_value = paginator
+
+    version = make_version("v1", datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
+    paginator.paginate.return_value = [{"Versions": [version]}]
+
+    folder_name = "resources_obj_gz"
+    output_dir = tmp_path / folder_name
+    output_dir.mkdir()
+    existing_file = output_dir / "20240601_120000_v1"
+    existing_file.write_bytes(b"existing")
+
+    download_versions(s3_client, "my-bucket", "resources/obj.gz", str(tmp_path))
+
+    s3_client.get_object.assert_not_called()
+    assert existing_file.read_bytes() == b"existing"
+
+
+def test_build_git_history_creates_commits(tmp_path: Path):
+    version_dir = tmp_path / "versions"
+    version_dir.mkdir()
+
+    (version_dir / "20240101_120000_v1").write_text(json.dumps({"version": 1}))
+    (version_dir / "20240102_120000_v2").write_text(json.dumps({"version": 2}))
+
+    build_git_history(version_dir)
+
+    result = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=version_dir,
+        capture_output=True,
+        text=True,
+    )
+    commit_messages = result.stdout.strip().splitlines()
+    assert any("20240102_120000_v2" in msg for msg in commit_messages)
+    assert any("20240101_120000_v1" in msg for msg in commit_messages)
+
+
+def test_build_git_history_skips_if_git_exists(tmp_path: Path):
+    version_dir = tmp_path / "versions"
+    version_dir.mkdir()
+    (version_dir / ".git").mkdir()
+
+    with patch("commands.services.s3_versions.subprocess.run") as mock_run:
+        build_git_history(version_dir)
+        mock_run.assert_not_called()

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -66,7 +66,9 @@ def test_try_pretty_json_returns_original_on_invalid_json():
     assert result == raw
 
 
-def make_version(version_id: str, last_modified: datetime, key: str = "resources/obj.gz") -> dict:
+def make_version(
+    version_id: str, last_modified: datetime, key: str = "resources/obj.gz"
+) -> dict:
     return {
         "Key": key,
         "VersionId": version_id,
@@ -95,8 +97,12 @@ def test_fetch_versions_filters_by_exact_key():
     paginator = MagicMock()
     s3_client.get_paginator.return_value = paginator
 
-    target = make_version("v1", datetime(2024, 1, 1, tzinfo=timezone.utc), key="resources/obj.gz")
-    other = make_version("v2", datetime(2024, 1, 2, tzinfo=timezone.utc), key="resources/obj-other.gz")
+    target = make_version(
+        "v1", datetime(2024, 1, 1, tzinfo=timezone.utc), key="resources/obj.gz"
+    )
+    other = make_version(
+        "v2", datetime(2024, 1, 2, tzinfo=timezone.utc), key="resources/obj-other.gz"
+    )
 
     paginator.paginate.return_value = [{"Versions": [target, other]}]
 
@@ -112,11 +118,19 @@ def test_download_versions_creates_files(tmp_path: Path):
     s3_client.get_paginator.return_value = paginator
 
     content = json.dumps({"id": "abc"}).encode()
-    version = make_version("abc123", datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc), key="resources/obj.json")
+    version = make_version(
+        "abc123",
+        datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+        key="resources/obj.json",
+    )
     paginator.paginate.return_value = [{"Versions": [version]}]
-    s3_client.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=content))}
+    s3_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=content))
+    }
 
-    output_dir = download_versions(s3_client, "my-bucket", "resources/obj.json", str(tmp_path))
+    output_dir = download_versions(
+        s3_client, "my-bucket", "resources/obj.json", str(tmp_path)
+    )
 
     files = list(output_dir.iterdir())
     assert len(files) == 1
@@ -132,9 +146,13 @@ def test_download_versions_decompresses_gz(tmp_path: Path):
     compressed = gzip.compress(json.dumps(original).encode())
     version = make_version("v1", datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
     paginator.paginate.return_value = [{"Versions": [version]}]
-    s3_client.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=compressed))}
+    s3_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=compressed))
+    }
 
-    output_dir = download_versions(s3_client, "my-bucket", "resources/obj.gz", str(tmp_path))
+    output_dir = download_versions(
+        s3_client, "my-bucket", "resources/obj.gz", str(tmp_path)
+    )
 
     files = list(output_dir.iterdir())
     assert len(files) == 1

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -171,7 +171,11 @@ def test_download_versions_skips_existing_files(tmp_path: Path):
     assert existing_file.read_bytes() == b"existing"
 
 
-def test_build_git_history_creates_commits(tmp_path: Path):
+def test_build_git_history_creates_commits(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.com")
     version_dir = tmp_path / "versions"
     version_dir.mkdir()
 

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -50,6 +50,7 @@ def test_decompress_if_needed_returns_raw_on_corrupt_gz(caplog):
     corrupt = b"not gzip data"
     result = decompress_if_needed(corrupt, "file.gz")
     assert result == corrupt
+    assert "Failed to decompress gz data" in caplog.text
 
 
 def test_try_pretty_json_formats_valid_json():


### PR DESCRIPTION
## Summary

- Adds new `s3` command group with two subcommands for downloading S3 object version history as local git commits
- Downloads all versions, decompresses `.gz` files, and pretty-prints JSON
- Each commit in the local git history represents one version — use `tig` to inspect changes interactively

### `get-versions` — convenient form with defaults
Resolves the bucket by name substring and prepends the `resources/` prefix automatically. The `.gz` extension is optional.

```bash
# Typical usage — no account ID or path needed
uv run cli.py s3 get-versions 0198cc81bda0-f0364528-cc85-4c74-817a-358147652aaa

# Override defaults
uv run cli.py s3 get-versions <object-key> --bucket persisted-resources --prefix resources/ --output-dir /tmp
```

### `get-versions-uri` — explicit full URI
Accepts `s3://bucket/key` or `bucket/key` for when you need full control.

```bash
uv run cli.py s3 get-versions-uri persisted-resources-XXXXXXXXXXXX/resources/<object-key>.gz
uv run cli.py s3 get-versions-uri s3://persisted-resources-XXXXXXXXXXXX/resources/<object-key>.gz
```

### Inspecting history

```bash
tig  # run inside the created version folder
```

https://sikt.atlassian.net/browse/NP-51185