### PR TITLE
fix: Clear AWS env variables in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,3 +7,5 @@ def block_real_aws_credentials(monkeypatch):
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_PROFILE", raising=False)


### PR DESCRIPTION
Clears AWS environment variables in tests that may leak from parent shell when running tests locally and cause credential resolution to fail.