### PR TITLE
fix(s3): commit identical S3 versions and isolate git config

### DIFF
--- a/commands/services/s3_versions.py
+++ b/commands/services/s3_versions.py
@@ -23,13 +23,21 @@ def _git(cwd: Path, *args: str) -> None:
     env = {
         **os.environ,
         **{k: v for k, v in _GIT_IDENTITY_DEFAULTS.items() if k not in os.environ},
+        # Isolate from the user's global/system git config (templates, hooks, signing, includeIf).
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
     }
     try:
         subprocess.run(
             ["git", *args], cwd=cwd, check=True, capture_output=True, env=env
         )
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(exc.stderr.decode(errors="replace").strip()) from exc
+        stderr = exc.stderr.decode(errors="replace").strip() if exc.stderr else ""
+        stdout = exc.stdout.decode(errors="replace").strip() if exc.stdout else ""
+        details = stderr or stdout or "(no output)"
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (exit {exc.returncode}) in {cwd}: {details}"
+        ) from exc
 
 
 def sanitize_to_folder_name(path: str) -> str:
@@ -146,7 +154,8 @@ def build_git_history(output_dir: Path, key: str = "") -> None:
     for filepath in version_files:
         object_file.write_bytes(filepath.read_bytes())
         _git(output_dir, "add", tracked_filename)
-        _git(output_dir, "commit", "-m", filepath.name)
+        # --allow-empty keeps a 1:1 commit-per-version mapping even when consecutive S3 versions are byte-identical.
+        _git(output_dir, "commit", "--allow-empty", "-m", filepath.name)
 
     logger.info(
         "Git history created with %d commits in %s", len(version_files), output_dir

--- a/commands/services/tests/test_s3_versions.py
+++ b/commands/services/tests/test_s3_versions.py
@@ -219,6 +219,33 @@ def test_build_git_history_creates_commits(tmp_path: Path, monkeypatch):
     assert any("20240101_120000_v1" in msg for msg in commit_messages)
 
 
+def test_build_git_history_commits_identical_versions(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.com")
+    version_dir = tmp_path / "versions"
+    version_dir.mkdir()
+
+    same_payload = json.dumps({"version": 1})
+    (version_dir / "20240101_120000_v1").write_text(same_payload)
+    (version_dir / "20240102_120000_v2").write_text(same_payload)
+
+    build_git_history(version_dir)
+
+    result = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=version_dir,
+        capture_output=True,
+        text=True,
+    )
+    commit_messages = result.stdout.strip().splitlines()
+    # init + v1 + v2 — even though v1 and v2 are byte-identical, both must commit.
+    assert len(commit_messages) == 3
+    assert any("20240101_120000_v1" in msg for msg in commit_messages)
+    assert any("20240102_120000_v2" in msg for msg in commit_messages)
+
+
 def test_build_git_history_skips_if_git_exists(tmp_path: Path):
     version_dir = tmp_path / "versions"
     version_dir.mkdir()


### PR DESCRIPTION
Fixes a bug in `s3 get-versions` where byte-identical consecutive S3 object versions were silently dropped from the generated git history, and hardens the git invocation.

- Use `git commit --allow-empty` so byte-identical consecutive S3 versions still produce a commit, keeping a 1:1 version-to-commit mapping
- Isolate the generated git history from the user's global/system git config (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) so templates, hooks, signing and `includeIf` don't leak in
- Improve git error messages with exit code, the failing command and working dir (falls back to stdout / `(no output)`)
- Add test covering identical-version commits

https://sikt.atlassian.net/browse/NP-51317