### PR TITLE
feat(reports): add author-shares-control report command

### DIFF
--- a/commands/reports.py
+++ b/commands/reports.py
@@ -7,7 +7,10 @@ import click
 import polars as pl
 
 from commands.services.api_client import ApiClient
-from commands.services.scientific_index_api import get_all_institutions_report
+from commands.services.scientific_index_api import (
+    get_all_institutions_report,
+    get_all_institutions_report_control,
+)
 from commands.utils import AppContext
 
 
@@ -28,11 +31,47 @@ def reports(ctx: AppContext):
 )
 @click.pass_obj
 def author_shares(ctx: AppContext, year: int, output: str | None):
+    _run_report(
+        ctx,
+        year,
+        output,
+        report_name="author_shares",
+        fetch=get_all_institutions_report,
+    )
+
+
+@reports.command(name="author-shares-control")
+@click.option(
+    "--year", default=lambda: datetime.now().year, show_default="current year", type=int
+)
+@click.option(
+    "--output",
+    default=None,
+    help="Output filename (defaults to author_shares_control_<profile>_<year>_<timestamp>.xlsx)",
+)
+@click.pass_obj
+def author_shares_control(ctx: AppContext, year: int, output: str | None):
+    _run_report(
+        ctx,
+        year,
+        output,
+        report_name="author_shares_control",
+        fetch=get_all_institutions_report_control,
+    )
+
+
+def _run_report(
+    ctx: AppContext,
+    year: int,
+    output: str | None,
+    report_name: str,
+    fetch,
+):
     client = ApiClient(session=ctx.session)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = output or f"author_shares_{ctx.profile}_{year}_{timestamp}.xlsx"
-    click.echo(f"Fetching author shares report for {year} (may take a few minutes)...")
-    data = get_all_institutions_report(client, year)
+    filename = output or f"{report_name}_{ctx.profile}_{year}_{timestamp}.xlsx"
+    click.echo(f"Fetching {report_name} report for {year} (may take a few minutes)...")
+    data = fetch(client, year)
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         warnings.filterwarnings("ignore", message="Ignoring URL", category=UserWarning)
     pl.read_excel(io.BytesIO(data)).write_excel(

--- a/commands/services/scientific_index_api.py
+++ b/commands/services/scientific_index_api.py
@@ -9,6 +9,7 @@ from commands.services.api_client import ApiClient
 logger = logging.getLogger(__name__)
 
 XLSX_AUTHOR_SHARES_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares"
+XLSX_AUTHOR_SHARES_CONTROL_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares-control"
 ALL_INSTITUTIONS_REPORT_PATH = "scientific-index/reports/{year}/institutions"
 POLL_INTERVAL_SECONDS = 5
 
@@ -16,10 +17,26 @@ POLL_INTERVAL_SECONDS = 5
 def get_all_institutions_report(
     client: ApiClient, year: int, timeout_minutes: int = 5
 ) -> bytes:
+    return _fetch_institutions_report(
+        client, year, XLSX_AUTHOR_SHARES_ACCEPT, timeout_minutes
+    )
+
+
+def get_all_institutions_report_control(
+    client: ApiClient, year: int, timeout_minutes: int = 5
+) -> bytes:
+    return _fetch_institutions_report(
+        client, year, XLSX_AUTHOR_SHARES_CONTROL_ACCEPT, timeout_minutes
+    )
+
+
+def _fetch_institutions_report(
+    client: ApiClient, year: int, accept: str, timeout_minutes: int
+) -> bytes:
     url = (
         f"https://{client.api_domain}/{ALL_INSTITUTIONS_REPORT_PATH.format(year=year)}"
     )
-    headers = {**client.auth_header(), "Accept": XLSX_AUTHOR_SHARES_ACCEPT}
+    headers = {**client.auth_header(), "Accept": accept}
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     presigned_url = response.json()["uri"]

--- a/commands/services/tests/test_scientific_index_api.py
+++ b/commands/services/tests/test_scientific_index_api.py
@@ -1,0 +1,113 @@
+import json
+from unittest.mock import patch
+
+import boto3
+import pytest
+import requests
+import responses
+from moto import mock_aws
+
+from commands.services.api_client import ApiClient
+from commands.services.scientific_index_api import (
+    XLSX_AUTHOR_SHARES_ACCEPT,
+    XLSX_AUTHOR_SHARES_CONTROL_ACCEPT,
+    get_all_institutions_report,
+    get_all_institutions_report_control,
+)
+
+API_DOMAIN = "api.example.org"
+COGNITO_URL = "https://cognito.example.org/oauth2/token"
+PRESIGNED_URL = "https://files.example.org/report.xlsx"
+A_YEAR = 2024
+REPORT_URL = f"https://{API_DOMAIN}/scientific-index/reports/{A_YEAR}/institutions"
+XLSX_BYTES = b"PK\x03\x04 fake xlsx"
+
+
+def _seed_aws() -> None:
+    ssm = boto3.client("ssm", region_name="eu-west-1")
+    ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
+    ssm.put_parameter(
+        Name="/NVA/CognitoUri", Value="https://cognito.example.org", Type="String"
+    )
+    boto3.client("secretsmanager", region_name="eu-west-1").create_secret(
+        Name="BackendCognitoClientCredentials",
+        SecretString=json.dumps(
+            {"backendClientId": "id", "backendClientSecret": "secret"}
+        ),
+    )
+
+
+def _add_cognito() -> None:
+    responses.add(
+        responses.POST, COGNITO_URL, json={"access_token": "token", "expires_in": 3600}
+    )
+
+
+def _client() -> ApiClient:
+    return ApiClient(session=boto3.Session(region_name="eu-west-1"))
+
+
+def _report_accept_header() -> str:
+    report_call = next(
+        call for call in responses.calls if call.request.url.startswith(REPORT_URL)
+    )
+    return report_call.request.headers["Accept"]
+
+
+@mock_aws
+@responses.activate
+def test_get_all_institutions_report_sends_author_shares_accept_header():
+    _seed_aws()
+    _add_cognito()
+    responses.add(responses.GET, REPORT_URL, json={"uri": PRESIGNED_URL})
+    responses.add(responses.GET, PRESIGNED_URL, body=XLSX_BYTES, status=200)
+
+    data = get_all_institutions_report(_client(), A_YEAR)
+
+    assert data == XLSX_BYTES
+    assert _report_accept_header() == XLSX_AUTHOR_SHARES_ACCEPT
+
+
+@mock_aws
+@responses.activate
+def test_get_all_institutions_report_control_sends_control_accept_header():
+    _seed_aws()
+    _add_cognito()
+    responses.add(responses.GET, REPORT_URL, json={"uri": PRESIGNED_URL})
+    responses.add(responses.GET, PRESIGNED_URL, body=XLSX_BYTES, status=200)
+
+    data = get_all_institutions_report_control(_client(), A_YEAR)
+
+    assert data == XLSX_BYTES
+    assert _report_accept_header() == XLSX_AUTHOR_SHARES_CONTROL_ACCEPT
+
+
+@mock_aws
+@responses.activate
+@patch("commands.services.scientific_index_api.time.sleep")
+def test_report_polls_presigned_url_until_ready(_sleep):
+    _seed_aws()
+    _add_cognito()
+    responses.add(responses.GET, REPORT_URL, json={"uri": PRESIGNED_URL})
+    responses.add(responses.GET, PRESIGNED_URL, status=404)
+    responses.add(responses.GET, PRESIGNED_URL, body=XLSX_BYTES, status=200)
+
+    data = get_all_institutions_report(_client(), A_YEAR)
+
+    assert data == XLSX_BYTES
+    presigned_calls = [
+        call for call in responses.calls if call.request.url == PRESIGNED_URL
+    ]
+    assert len(presigned_calls) == 2
+
+
+@mock_aws
+@responses.activate
+def test_report_raises_on_non_404_presigned_error():
+    _seed_aws()
+    _add_cognito()
+    responses.add(responses.GET, REPORT_URL, json={"uri": PRESIGNED_URL})
+    responses.add(responses.GET, PRESIGNED_URL, status=500)
+
+    with pytest.raises(requests.HTTPError):
+        get_all_institutions_report(_client(), A_YEAR)

--- a/commands/tests/test_reports_cli.py
+++ b/commands/tests/test_reports_cli.py
@@ -1,0 +1,92 @@
+import io
+import os
+from unittest.mock import patch
+
+import boto3
+import polars as pl
+from click.testing import CliRunner
+
+from commands.reports import reports
+from commands.utils import AppContext
+
+A_PROFILE = "test"
+A_YEAR = 2024
+
+
+def _ctx() -> AppContext:
+    return AppContext(
+        log_level=0,
+        profile=A_PROFILE,
+        session=boto3.Session(region_name="eu-west-1"),
+    )
+
+
+def _xlsx_bytes() -> bytes:
+    buffer = io.BytesIO()
+    pl.DataFrame({"institution": ["NTNU"], "shares": [1.0]}).write_excel(buffer)
+    return buffer.getvalue()
+
+
+def test_author_shares_calls_author_shares_fetch_and_names_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with (
+            patch(
+                "commands.reports.get_all_institutions_report",
+                return_value=_xlsx_bytes(),
+            ) as fetch,
+            patch(
+                "commands.reports.get_all_institutions_report_control"
+            ) as control_fetch,
+        ):
+            result = runner.invoke(
+                reports, ["author-shares", "--year", str(A_YEAR)], obj=_ctx()
+            )
+
+        assert result.exit_code == 0, result.output
+        fetch.assert_called_once()
+        control_fetch.assert_not_called()
+        written = os.listdir(".")
+        assert len(written) == 1
+        assert written[0].startswith(f"author_shares_{A_PROFILE}_{A_YEAR}_")
+        assert written[0].endswith(".xlsx")
+
+
+def test_author_shares_control_calls_control_fetch_and_names_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with (
+            patch(
+                "commands.reports.get_all_institutions_report_control",
+                return_value=_xlsx_bytes(),
+            ) as control_fetch,
+            patch("commands.reports.get_all_institutions_report") as fetch,
+        ):
+            result = runner.invoke(
+                reports, ["author-shares-control", "--year", str(A_YEAR)], obj=_ctx()
+            )
+
+        assert result.exit_code == 0, result.output
+        control_fetch.assert_called_once()
+        fetch.assert_not_called()
+        written = os.listdir(".")
+        assert len(written) == 1
+        assert written[0].startswith(f"author_shares_control_{A_PROFILE}_{A_YEAR}_")
+        assert written[0].endswith(".xlsx")
+
+
+def test_output_option_overrides_generated_filename():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with patch(
+            "commands.reports.get_all_institutions_report",
+            return_value=_xlsx_bytes(),
+        ):
+            result = runner.invoke(
+                reports,
+                ["author-shares", "--year", str(A_YEAR), "--output", "custom.xlsx"],
+                obj=_ctx(),
+            )
+
+        assert result.exit_code == 0, result.output
+        assert os.path.exists("custom.xlsx")


### PR DESCRIPTION
Adds a new `author-shares-control` report command alongside the existing `author-shares` report.

- Add `author-shares-control` CLI command that fetches the control variant of the all-institutions report
- Add `get_all_institutions_report_control` using the `author-shares-control` Accept profile header
- Extract shared `_fetch_institutions_report` (polling logic) and `_run_report` (CLI handling) to avoid duplication between the two report commands
- Add tests for the scientific index API (Accept header routing, polling, error propagation) and the reports CLI (command routing, filename generation, `--output` override)