### PR TITLE
feat(reports): add institution filter to author-shares report

### DIFF
--- a/commands/reports.py
+++ b/commands/reports.py
@@ -22,17 +22,31 @@ def reports(ctx: AppContext):
     "--year", default=lambda: datetime.now().year, show_default="current year", type=int
 )
 @click.option(
+    "--institution",
+    default=None,
+    help="Institution identifier (e.g., 20754.0.0.0). Defaults to all institutions.",
+)
+@click.option(
     "--output",
     default=None,
-    help="Output filename (defaults to author_shares_<profile>_<year>_<timestamp>.xlsx)",
+    help="Output filename (defaults to author_shares_<profile>_<year>[_<institution>]_<timestamp>.xlsx)",
 )
 @click.pass_obj
-def author_shares(ctx: AppContext, year: int, output: str | None):
+def author_shares(
+    ctx: AppContext, year: int, institution: str | None, output: str | None
+):
     client = ApiClient(session=ctx.session)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = output or f"author_shares_{ctx.profile}_{year}_{timestamp}.xlsx"
-    click.echo(f"Fetching author shares report for {year} (may take a few minutes)...")
-    data = get_all_institutions_report(client, year)
+    institution_suffix = f"_{institution}" if institution else ""
+    filename = (
+        output
+        or f"author_shares_{ctx.profile}_{year}{institution_suffix}_{timestamp}.xlsx"
+    )
+    scope = f"institution {institution}" if institution else "all institutions"
+    click.echo(
+        f"Fetching author shares report for {year} ({scope}) (may take a few minutes)..."
+    )
+    data = get_all_institutions_report(client, year, institution=institution)
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         warnings.filterwarnings("ignore", message="Ignoring URL", category=UserWarning)
     pl.read_excel(io.BytesIO(data)).write_excel(

--- a/commands/services/scientific_index_api.py
+++ b/commands/services/scientific_index_api.py
@@ -9,17 +9,48 @@ from commands.services.api_client import ApiClient
 logger = logging.getLogger(__name__)
 
 XLSX_AUTHOR_SHARES_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares"
+XLSX_AUTHOR_SHARES_CONTROL_ACCEPT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; profile=https://api.nva.unit.no/report/author-shares-control"
 ALL_INSTITUTIONS_REPORT_PATH = "scientific-index/reports/{year}/institutions"
+INSTITUTION_REPORT_PATH = "scientific-index/reports/{year}/institutions/{institution}"
 POLL_INTERVAL_SECONDS = 5
 
 
 def get_all_institutions_report(
-    client: ApiClient, year: int, timeout_minutes: int = 5
+    client: ApiClient,
+    year: int,
+    timeout_minutes: int = 5,
+    institution: str | None = None,
 ) -> bytes:
-    url = (
-        f"https://{client.api_domain}/{ALL_INSTITUTIONS_REPORT_PATH.format(year=year)}"
+    return _fetch_institutions_report(
+        client, year, XLSX_AUTHOR_SHARES_ACCEPT, timeout_minutes, institution
     )
-    headers = {**client.auth_header(), "Accept": XLSX_AUTHOR_SHARES_ACCEPT}
+
+
+def get_all_institutions_report_control(
+    client: ApiClient,
+    year: int,
+    timeout_minutes: int = 5,
+    institution: str | None = None,
+) -> bytes:
+    return _fetch_institutions_report(
+        client, year, XLSX_AUTHOR_SHARES_CONTROL_ACCEPT, timeout_minutes, institution
+    )
+
+
+def _fetch_institutions_report(
+    client: ApiClient,
+    year: int,
+    accept: str,
+    timeout_minutes: int,
+    institution: str | None = None,
+) -> bytes:
+    path = (
+        INSTITUTION_REPORT_PATH.format(year=year, institution=institution)
+        if institution
+        else ALL_INSTITUTIONS_REPORT_PATH.format(year=year)
+    )
+    url = f"https://{client.api_domain}/{path}"
+    headers = {**client.auth_header(), "Accept": accept}
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     presigned_url = response.json()["uri"]

--- a/commands/services/tests/test_scientific_index_api.py
+++ b/commands/services/tests/test_scientific_index_api.py
@@ -1,0 +1,161 @@
+import json
+
+import boto3
+import pytest
+import responses
+from moto import mock_aws
+
+from commands.services.api_client import ApiClient
+from commands.services.scientific_index_api import (
+    XLSX_AUTHOR_SHARES_ACCEPT,
+    XLSX_AUTHOR_SHARES_CONTROL_ACCEPT,
+    get_all_institutions_report,
+    get_all_institutions_report_control,
+)
+
+API_DOMAIN = "api.example.org"
+COGNITO_URL = "https://cognito.example.org/oauth2/token"
+PRESIGNED_URL = "https://s3.example.org/report.xlsx"
+A_YEAR = 2024
+AN_INSTITUTION = "20754.0.0.0"
+REPORT_BYTES = b"xlsx-content"
+ALL_INSTITUTIONS_URL = (
+    f"https://{API_DOMAIN}/scientific-index/reports/{A_YEAR}/institutions"
+)
+INSTITUTION_URL = f"{ALL_INSTITUTIONS_URL}/{AN_INSTITUTION}"
+
+
+def _client() -> ApiClient:
+    return ApiClient(session=boto3.Session(region_name="eu-west-1"))
+
+
+def _seed_aws() -> None:
+    ssm = boto3.client("ssm", region_name="eu-west-1")
+    ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
+    ssm.put_parameter(
+        Name="/NVA/CognitoUri", Value="https://cognito.example.org", Type="String"
+    )
+    boto3.client("secretsmanager", region_name="eu-west-1").create_secret(
+        Name="BackendCognitoClientCredentials",
+        SecretString=json.dumps(
+            {"backendClientId": "id", "backendClientSecret": "secret"}
+        ),
+    )
+
+
+def _add_cognito() -> None:
+    responses.add(
+        responses.POST, COGNITO_URL, json={"access_token": "token", "expires_in": 3600}
+    )
+
+
+def _add_report_redirect(url: str) -> None:
+    responses.add(responses.GET, url, json={"uri": PRESIGNED_URL})
+
+
+def _add_presigned_xlsx() -> None:
+    responses.add(responses.GET, PRESIGNED_URL, body=REPORT_BYTES, status=200)
+
+
+@mock_aws
+@responses.activate
+def test_all_institutions_report_uses_all_institutions_path():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(ALL_INSTITUTIONS_URL)
+    _add_presigned_xlsx()
+
+    data = get_all_institutions_report(_client(), A_YEAR)
+
+    assert data == REPORT_BYTES
+    report_call = next(
+        c for c in responses.calls if c.request.url == ALL_INSTITUTIONS_URL
+    )
+    assert report_call.request.headers["Accept"] == XLSX_AUTHOR_SHARES_ACCEPT
+
+
+@mock_aws
+@responses.activate
+def test_report_with_institution_uses_institution_path():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(INSTITUTION_URL)
+    _add_presigned_xlsx()
+
+    data = get_all_institutions_report(_client(), A_YEAR, institution=AN_INSTITUTION)
+
+    assert data == REPORT_BYTES
+    assert any(c.request.url == INSTITUTION_URL for c in responses.calls)
+    assert all(c.request.url != ALL_INSTITUTIONS_URL for c in responses.calls)
+
+
+@mock_aws
+@responses.activate
+def test_control_report_uses_control_accept_header():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(ALL_INSTITUTIONS_URL)
+    _add_presigned_xlsx()
+
+    get_all_institutions_report_control(_client(), A_YEAR)
+
+    report_call = next(
+        c for c in responses.calls if c.request.url == ALL_INSTITUTIONS_URL
+    )
+    assert report_call.request.headers["Accept"] == XLSX_AUTHOR_SHARES_CONTROL_ACCEPT
+
+
+@mock_aws
+@responses.activate
+def test_control_report_with_institution_uses_institution_path_and_control_accept():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(INSTITUTION_URL)
+    _add_presigned_xlsx()
+
+    get_all_institutions_report_control(_client(), A_YEAR, institution=AN_INSTITUTION)
+
+    report_call = next(c for c in responses.calls if c.request.url == INSTITUTION_URL)
+    assert report_call.request.headers["Accept"] == XLSX_AUTHOR_SHARES_CONTROL_ACCEPT
+
+
+@mock_aws
+@responses.activate
+def test_report_polls_until_presigned_url_ready(monkeypatch):
+    monkeypatch.setattr(
+        "commands.services.scientific_index_api.time.sleep", lambda _: None
+    )
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(ALL_INSTITUTIONS_URL)
+    responses.add(responses.GET, PRESIGNED_URL, status=404)
+    responses.add(responses.GET, PRESIGNED_URL, body=REPORT_BYTES, status=200)
+
+    data = get_all_institutions_report(_client(), A_YEAR)
+
+    assert data == REPORT_BYTES
+    presigned_calls = [c for c in responses.calls if c.request.url == PRESIGNED_URL]
+    assert len(presigned_calls) == 2
+
+
+@mock_aws
+@responses.activate
+def test_report_raises_timeout_when_never_ready():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(ALL_INSTITUTIONS_URL)
+
+    with pytest.raises(TimeoutError):
+        get_all_institutions_report(_client(), A_YEAR, timeout_minutes=0)
+
+
+@mock_aws
+@responses.activate
+def test_report_raises_on_server_error_from_presigned_url():
+    _seed_aws()
+    _add_cognito()
+    _add_report_redirect(ALL_INSTITUTIONS_URL)
+    responses.add(responses.GET, PRESIGNED_URL, status=500)
+
+    with pytest.raises(Exception):
+        get_all_institutions_report(_client(), A_YEAR)

--- a/commands/tests/test_reports_cli.py
+++ b/commands/tests/test_reports_cli.py
@@ -1,0 +1,127 @@
+import glob
+import io
+import json
+
+import boto3
+import polars as pl
+import responses
+from click.testing import CliRunner
+from moto import mock_aws
+
+from commands.reports import reports
+from commands.utils import AppContext
+
+API_DOMAIN = "api.example.org"
+COGNITO_URL = "https://cognito.example.org/oauth2/token"
+PRESIGNED_URL = "https://s3.example.org/report.xlsx"
+A_YEAR = 2024
+A_PROFILE = "testprofile"
+AN_INSTITUTION = "20754.0.0.0"
+ALL_INSTITUTIONS_URL = (
+    f"https://{API_DOMAIN}/scientific-index/reports/{A_YEAR}/institutions"
+)
+INSTITUTION_URL = f"{ALL_INSTITUTIONS_URL}/{AN_INSTITUTION}"
+
+
+def _ctx() -> AppContext:
+    return AppContext(
+        log_level=0,
+        profile=A_PROFILE,
+        session=boto3.Session(region_name="eu-west-1"),
+    )
+
+
+def _seed_aws() -> None:
+    ssm = boto3.client("ssm", region_name="eu-west-1")
+    ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
+    ssm.put_parameter(
+        Name="/NVA/CognitoUri", Value="https://cognito.example.org", Type="String"
+    )
+    boto3.client("secretsmanager", region_name="eu-west-1").create_secret(
+        Name="BackendCognitoClientCredentials",
+        SecretString=json.dumps(
+            {"backendClientId": "id", "backendClientSecret": "secret"}
+        ),
+    )
+
+
+def _add_cognito() -> None:
+    responses.add(
+        responses.POST, COGNITO_URL, json={"access_token": "token", "expires_in": 3600}
+    )
+
+
+def _an_xlsx_report() -> bytes:
+    buffer = io.BytesIO()
+    pl.DataFrame({"institution": ["NTNU"], "shares": [1.0]}).write_excel(buffer)
+    return buffer.getvalue()
+
+
+def _add_report(report_url: str) -> None:
+    responses.add(responses.GET, report_url, json={"uri": PRESIGNED_URL})
+    responses.add(responses.GET, PRESIGNED_URL, body=_an_xlsx_report(), status=200)
+
+
+@mock_aws
+@responses.activate
+def test_author_shares_without_institution_targets_all_institutions():
+    _seed_aws()
+    _add_cognito()
+    _add_report(ALL_INSTITUTIONS_URL)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            reports, ["author-shares", "--year", str(A_YEAR)], obj=_ctx()
+        )
+
+        assert result.exit_code == 0, result.output
+        files = glob.glob("*.xlsx")
+        assert len(files) == 1
+        assert files[0].startswith(f"author_shares_{A_PROFILE}_{A_YEAR}_")
+        assert AN_INSTITUTION not in files[0]
+    assert any(c.request.url == ALL_INSTITUTIONS_URL for c in responses.calls)
+
+
+@mock_aws
+@responses.activate
+def test_author_shares_with_institution_targets_institution_and_names_file():
+    _seed_aws()
+    _add_cognito()
+    _add_report(INSTITUTION_URL)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            reports,
+            ["author-shares", "--year", str(A_YEAR), "--institution", AN_INSTITUTION],
+            obj=_ctx(),
+        )
+
+        assert result.exit_code == 0, result.output
+        files = glob.glob("*.xlsx")
+        assert len(files) == 1
+        assert files[0].startswith(
+            f"author_shares_{A_PROFILE}_{A_YEAR}_{AN_INSTITUTION}_"
+        )
+    assert any(c.request.url == INSTITUTION_URL for c in responses.calls)
+    assert all(c.request.url != ALL_INSTITUTIONS_URL for c in responses.calls)
+
+
+@mock_aws
+@responses.activate
+def test_author_shares_respects_explicit_output_filename():
+    _seed_aws()
+    _add_cognito()
+    _add_report(ALL_INSTITUTIONS_URL)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            reports,
+            ["author-shares", "--year", str(A_YEAR), "--output", "custom.xlsx"],
+            obj=_ctx(),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert glob.glob("*.xlsx") == ["custom.xlsx"]


### PR DESCRIPTION
Adds the ability to scope the author-shares report to a single institution instead of always fetching all institutions.

- Add `--institution` option to the `author-shares` report command (defaults to all institutions)
- Include the institution identifier in the default output filename when provided
- Add `get_all_institutions_report_control` for the author-shares-control report profile
- Extract shared `_fetch_institutions_report` helper supporting an optional institution path

https://sikt.atlassian.net/browse/NP-51737