### PR TITLE
feat(search): add JSONL batch export and search-after pagination

### DIFF
--- a/commands/search.py
+++ b/commands/search.py
@@ -168,7 +168,7 @@ def search(ctx: AppContext):
     "--output",
     "-o",
     type=click.Path(dir_okay=False, writable=True),
-    help="Write results as JSONL to this file (one JSON object per line)",
+    help="Write results as JSONL to this file (one JSON object per line). May include a directory path, which is created if missing",
 )
 @click.option(
     "--batch-size",
@@ -323,6 +323,7 @@ class _JsonlSink:
         self._close_current_file()
         path = self._batch_path()
         self._paths.append(path)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
         self._file = open(path, "w", encoding="utf-8")
         self._lines_in_batch = 0
 

--- a/commands/search.py
+++ b/commands/search.py
@@ -170,7 +170,7 @@ def search(ctx: AppContext):
     "--output",
     "-o",
     type=click.Path(dir_okay=False, writable=True),
-    help="Write results to this file, one per line: JSON objects, or bare identifiers with --id-only. May include a directory path, which is created if missing",
+    help="Base path for JSONL output; a zero-padded batch number is inserted before the extension (e.g. out.jsonl -> out_00001.jsonl). Lines are JSON objects, or bare identifiers with --id-only. Missing directories are created",
 )
 @click.option(
     "--batch-size",

--- a/commands/search.py
+++ b/commands/search.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple
 
+from tqdm import tqdm
+
 from commands.services.search_api import SearchApiService
 from commands.utils import AppContext
 
@@ -239,13 +241,27 @@ def resources(
             logger.warning(f"Ignoring invalid query parameter: {q}")
 
     compact = output is not None
+    progress_bar = None
+
+    def start_progress(total_hits: int) -> None:
+        nonlocal progress_bar
+        capped_total = min(total_hits, limit) if limit else total_hits
+        progress_bar = tqdm(
+            total=capped_total, unit="hit", desc="Fetching", disable=None
+        )
 
     try:
         with _JsonlSink(output, batch_size) as sink:
             count = 0
             for hit in search_service.resource_search(
-                query_params, page_size, api_version=api_version
+                query_params,
+                page_size,
+                api_version=api_version,
+                on_total_hits=start_progress,
             ):
+                if progress_bar is not None:
+                    progress_bar.update(1)
+
                 line = _format_hit_line(hit, id_only, compact)
                 if line is not None:
                     sink.write(line)
@@ -260,6 +276,9 @@ def resources(
     except Exception as e:
         logger.error(f"Error fetching resources: {e}")
         raise click.Abort()
+    finally:
+        if progress_bar is not None:
+            progress_bar.close()
 
 
 def _format_hit_line(hit: dict, id_only: bool, compact: bool) -> str | None:

--- a/commands/search.py
+++ b/commands/search.py
@@ -170,7 +170,7 @@ def search(ctx: AppContext):
     "--output",
     "-o",
     type=click.Path(dir_okay=False, writable=True),
-    help="Write results as JSONL to this file (one JSON object per line). May include a directory path, which is created if missing",
+    help="Write results to this file, one per line: JSON objects, or bare identifiers with --id-only. May include a directory path, which is created if missing",
 )
 @click.option(
     "--batch-size",
@@ -220,11 +220,11 @@ def resources(
         uv run cli.py search resources --publisher 08DC24C9-B7FF-4192-89AC-C629D93AD9CF --id-only
 
         # Write results to JSONL files, split into batches of 1000 (default)
-        uv run cli.py search resources --unit 194.0.0.00 --output resultat.jsonl
+        uv run cli.py search resources --unit 194.0.0.0 --output resultat.jsonl
         # -> resultat_00001.jsonl, resultat_00002.jsonl, ...
 
         # Override the batch size
-        uv run cli.py search resources --unit 194.0.0.00 --output resultat.jsonl --batch-size 500
+        uv run cli.py search resources --unit 194.0.0.0 --output resultat.jsonl --batch-size 500
 
         # Use additional query parameters
         uv run cli.py search resources --query "funding=some-id" --query "status=published" --aggregation all

--- a/commands/search.py
+++ b/commands/search.py
@@ -2,6 +2,7 @@ import click
 import json
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Tuple
 
 from commands.services.search_api import SearchApiService
@@ -164,6 +165,19 @@ def search(ctx: AppContext):
     help="Output only identifiers (one per line)",
 )
 @click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Write results as JSONL to this file (one JSON object per line)",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=1000,
+    show_default=True,
+    help="When writing to --output, split into files of this many records (a zero-padded counter is inserted before the extension)",
+)
+@click.option(
     "--query",
     type=str,
     multiple=True,
@@ -180,6 +194,8 @@ def resources(
     page_size: int,
     limit: int | None,
     id_only: bool,
+    output: str | None,
+    batch_size: int,
     query: Tuple[str, ...],
     api_version: str,
     **kwargs,
@@ -201,6 +217,13 @@ def resources(
         # Search by publisher (output only IDs)
         uv run cli.py search resources --publisher 08DC24C9-B7FF-4192-89AC-C629D93AD9CF --id-only
 
+        # Write results to JSONL files, split into batches of 1000 (default)
+        uv run cli.py search resources --unit 194.0.0.00 --output resultat.jsonl
+        # -> resultat_00001.jsonl, resultat_00002.jsonl, ...
+
+        # Override the batch size
+        uv run cli.py search resources --unit 194.0.0.00 --output resultat.jsonl --batch-size 500
+
         # Use additional query parameters
         uv run cli.py search resources --query "funding=some-id" --query "status=published" --aggregation all
     """
@@ -215,25 +238,100 @@ def resources(
         else:
             logger.warning(f"Ignoring invalid query parameter: {q}")
 
+    compact = output is not None
+
     try:
-        count = 0
-        for hit in search_service.resource_search(
-            query_params, page_size, api_version=api_version
-        ):
-            if id_only:
-                identifier = hit.get("identifier")
-                if identifier:
-                    print(identifier)
-            else:
-                print(json.dumps(hit, indent=2))
-            count += 1
+        with _JsonlSink(output, batch_size) as sink:
+            count = 0
+            for hit in search_service.resource_search(
+                query_params, page_size, api_version=api_version
+            ):
+                line = _format_hit_line(hit, id_only, compact)
+                if line is not None:
+                    sink.write(line)
+                    count += 1
 
-            if limit and count >= limit:
-                break
+                if limit and count >= limit:
+                    break
 
-        if count > 0:
-            logger.info(f"Total results: {count}")
+            if count > 0:
+                _log_result_summary(count, output, batch_size, sink.paths)
 
     except Exception as e:
         logger.error(f"Error fetching resources: {e}")
         raise click.Abort()
+
+
+def _format_hit_line(hit: dict, id_only: bool, compact: bool) -> str | None:
+    if id_only:
+        return hit.get("identifier")
+    if compact:
+        return json.dumps(hit)
+    return json.dumps(hit, indent=2)
+
+
+def _log_result_summary(
+    count: int, output: str | None, batch_size: int, paths: list
+) -> None:
+    if output is None:
+        logger.info(f"Total results: {count}")
+    elif len(paths) == 1:
+        logger.info(f"Wrote {count} results to {paths[0]}")
+    else:
+        logger.info(
+            f"Wrote {count} results to {len(paths)} files "
+            f"({paths[0]} … {paths[-1]}, {batch_size} per file)"
+        )
+
+
+class _JsonlSink:
+    def __init__(self, output: str | None, batch_size: int) -> None:
+        self._output = output
+        self._batch_size = batch_size
+        self._file = None
+        self._paths = []
+        self._lines_in_batch = 0
+
+    def __enter__(self) -> "_JsonlSink":
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        self._close_current_file()
+        return False
+
+    @property
+    def paths(self) -> list:
+        return self._paths
+
+    @property
+    def file_count(self) -> int:
+        return len(self._paths)
+
+    def write(self, line: str) -> None:
+        if self._output is None:
+            print(line)
+            return
+
+        if self._file is None or self._lines_in_batch >= self._batch_size:
+            self._open_next_file()
+
+        self._file.write(line)
+        self._file.write("\n")
+        self._lines_in_batch += 1
+
+    def _open_next_file(self) -> None:
+        self._close_current_file()
+        path = self._batch_path()
+        self._paths.append(path)
+        self._file = open(path, "w", encoding="utf-8")
+        self._lines_in_batch = 0
+
+    def _batch_path(self) -> str:
+        next_index = len(self._paths) + 1
+        path = Path(self._output)
+        return str(path.with_name(f"{path.stem}_{next_index:05d}{path.suffix}"))
+
+    def _close_current_file(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -116,13 +116,13 @@ class SearchApiService:
             yield from hits
 
             url = response_data.get(self.NEXT_PAGE_FIELD)
-            params = None
+            params = {}
 
     def _fetch_search_page(
         self,
         url: str,
         headers: Dict[str, str],
-        params: Dict[str, Any] | None,
+        params: Dict[str, Any],
     ) -> Dict[str, Any] | None:
         try:
             response = self._make_search_request(url, headers, params)

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -8,7 +8,7 @@ from tenacity import (
     wait_exponential,
     retry_if_exception_type,
 )
-from typing import Dict, Any, Generator
+from typing import Dict, Any, Callable, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,7 @@ class SearchApiService:
         query_parameters: Dict[str, Any],
         page_size: int = 100,
         api_version: str = "2024-12-01",
+        on_total_hits: Callable[[int], None] | None = None,
     ) -> Generator[Dict[str, Any], None, None]:
         """
         Search resources with automatic pagination using search-after.
@@ -83,6 +84,8 @@ class SearchApiService:
             query_parameters: Dictionary of query parameters (without pagination keys)
             page_size: Number of results per page (default: 100)
             api_version: API version to use in Accept header (default: 2024-12-01)
+            on_total_hits: Optional callback invoked once with ``totalHits`` from
+                the first page, e.g. to size a progress bar
 
         Yields:
             Individual hits from the search results
@@ -95,11 +98,16 @@ class SearchApiService:
             **query_parameters,
             "results": page_size,
         }
+        total_reported = False
 
         while url:
             response_data = self._fetch_search_page(url, headers, params)
             if response_data is None:
                 break
+
+            if on_total_hits is not None and not total_reported:
+                on_total_hits(response_data.get("totalHits", 0))
+                total_reported = True
 
             hits = response_data.get("hits", [])
             if not hits:

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -12,6 +12,8 @@ from typing import Dict, Any, Callable, Generator
 
 logger = logging.getLogger(__name__)
 
+USER_AGENT = "nva-aws-cli-tools (+https://github.com/BIBSYSDEV/nva-aws-cli-tools)"
+
 
 class SearchApiService:
     NEXT_PAGE_FIELD = "nextSearchAfterResults"
@@ -92,6 +94,7 @@ class SearchApiService:
         """
         headers = {
             "Accept": f"application/json; version={api_version}",
+            "User-Agent": USER_AGENT,
         }
         url = self.get_uri("resources")
         params = {

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -145,7 +145,11 @@ class SearchApiService:
             return None
 
         if response.status_code != 200:
-            logger.error(f"Failed to search. {response.status_code}: {response.json()}")
+            logger.error(f"Failed to search. {response.status_code}: {response.text}")
             return None
 
-        return response.json()
+        try:
+            return response.json()
+        except ValueError, JSONDecodeError:
+            logger.error(f"Search response was not valid JSON: {response.text}")
+            return None

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -1,7 +1,6 @@
 import boto3
 import logging
 import requests
-from requests.exceptions import JSONDecodeError
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -137,7 +136,7 @@ class SearchApiService:
                 try:
                     error_detail = e.response.json()
                     logger.error(f"Error detail: {error_detail}")
-                except ValueError, JSONDecodeError:
+                except ValueError:
                     logger.error(f"Error detail: {e.response.text}")
             return None
         except requests.exceptions.RequestException as e:
@@ -150,6 +149,6 @@ class SearchApiService:
 
         try:
             return response.json()
-        except ValueError, JSONDecodeError:
+        except ValueError:
             logger.error(f"Search response was not valid JSON: {response.text}")
             return None

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class SearchApiService:
+    NEXT_PAGE_FIELD = "nextSearchAfterResults"
+
     def __init__(self, session: boto3.Session) -> None:
         self.session = session
         self.ssm = self.session.client("ssm")
@@ -71,64 +73,68 @@ class SearchApiService:
         api_version: str = "2024-12-01",
     ) -> Generator[Dict[str, Any], None, None]:
         """
-        Search resources with automatic pagination.
+        Search resources with automatic pagination using search-after.
+
+        Pagination follows the ``nextSearchAfterResults`` link returned in the
+        response body instead of an incrementing ``from`` offset. This avoids the
+        offset window limit and lets us page through arbitrarily large result sets.
 
         Args:
-            query_parameters: Dictionary of query parameters (without 'from' and 'results')
+            query_parameters: Dictionary of query parameters (without pagination keys)
             page_size: Number of results per page (default: 100)
             api_version: API version to use in Accept header (default: 2024-12-01)
 
         Yields:
             Individual hits from the search results
         """
-        url = self.get_uri("resources")
         headers = {
             "Accept": f"application/json; version={api_version}",
         }
-        offset = 0
+        url = self.get_uri("resources")
+        params = {
+            **query_parameters,
+            "results": page_size,
+        }
 
-        while True:
-            params = {
-                **query_parameters,
-                "from": offset,
-                "results": page_size,
-            }
-
-            try:
-                response = self._make_search_request(url, headers, params)
-            except requests.exceptions.HTTPError as e:
-                logger.error(
-                    f"Failed to search after retries. Status: {e.response.status_code}",
-                )
-                if e.response.status_code >= 400:
-                    try:
-                        error_detail = e.response.json()
-                        logger.error(f"Error detail: {error_detail}")
-                    except ValueError, JSONDecodeError:
-                        logger.error(f"Error detail: {e.response.text}")
-                break
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Network error after retries: {e}")
+        while url:
+            response_data = self._fetch_search_page(url, headers, params)
+            if response_data is None:
                 break
 
-            if response.status_code != 200:
-                logger.error(
-                    f"Failed to search. {response.status_code}: {response.json()}"
-                )
-                break
-
-            response_data = response.json()
             hits = response_data.get("hits", [])
-
             if not hits:
                 break
 
-            for hit in hits:
-                yield hit
+            yield from hits
 
-            # Check if we've retrieved all results
-            total_hits = response_data.get("totalHits", 0)
-            offset += len(hits)
+            url = response_data.get(self.NEXT_PAGE_FIELD)
+            params = None
 
-            if offset >= total_hits:
-                break
+    def _fetch_search_page(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any] | None,
+    ) -> Dict[str, Any] | None:
+        try:
+            response = self._make_search_request(url, headers, params)
+        except requests.exceptions.HTTPError as e:
+            logger.error(
+                f"Failed to search after retries. Status: {e.response.status_code}",
+            )
+            if e.response.status_code >= 400:
+                try:
+                    error_detail = e.response.json()
+                    logger.error(f"Error detail: {error_detail}")
+                except ValueError, JSONDecodeError:
+                    logger.error(f"Error detail: {e.response.text}")
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Network error after retries: {e}")
+            return None
+
+        if response.status_code != 200:
+            logger.error(f"Failed to search. {response.status_code}: {response.json()}")
+            return None
+
+        return response.json()

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -171,6 +171,18 @@ def test_client_error_stops_pagination():
 
 @mock_aws
 @responses.activate
+def test_invalid_json_body_yields_nothing_without_crashing():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, body="<html>not json</html>", status=200)
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}))
+
+    assert hits == []
+    assert len(responses.calls) == 1
+
+
+@mock_aws
+@responses.activate
 def test_persistent_server_error_gives_up_and_yields_nothing(monkeypatch):
     monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
     _seed_ssm()

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -1,0 +1,144 @@
+import urllib.parse
+
+import boto3
+import responses
+from moto import mock_aws
+
+from commands.services.search_api import SearchApiService
+
+API_DOMAIN = "api.example.org"
+SEARCH_URL = f"https://{API_DOMAIN}/search/resources"
+NEXT_URL = f"{SEARCH_URL}?searchAfter=next-cursor&results=2"
+
+
+def _seed_ssm() -> None:
+    ssm = boto3.client("ssm", region_name="eu-west-1")
+    ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
+
+
+def _a_service() -> SearchApiService:
+    return SearchApiService(boto3.Session(region_name="eu-west-1"))
+
+
+def _a_hit(identifier: str) -> dict:
+    return {"identifier": identifier, "type": "Publication"}
+
+
+def _query_params(call) -> dict:
+    query = urllib.parse.urlparse(call.request.url).query
+    return dict(urllib.parse.parse_qsl(query))
+
+
+@mock_aws
+@responses.activate
+def test_single_page_without_next_link_yields_all_hits():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a"), _a_hit("b")]})
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=50))
+
+    assert [hit["identifier"] for hit in hits] == ["a", "b"]
+    assert len(responses.calls) == 1
+
+
+@mock_aws
+@responses.activate
+def test_first_request_uses_results_and_no_from_offset():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    list(_a_service().resource_search({"aggregation": "none"}, page_size=25))
+
+    params = _query_params(responses.calls[0])
+    assert params["results"] == "25"
+    assert params["aggregation"] == "none"
+    assert "from" not in params
+
+
+@mock_aws
+@responses.activate
+def test_follows_next_search_after_link_across_pages():
+    _seed_ssm()
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        json={"hits": [_a_hit("a"), _a_hit("b")], "nextSearchAfterResults": NEXT_URL},
+    )
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("c")]})
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=2))
+
+    assert [hit["identifier"] for hit in hits] == ["a", "b", "c"]
+    assert len(responses.calls) == 2
+    assert "searchAfter=next-cursor" in responses.calls[1].request.url
+
+
+@mock_aws
+@responses.activate
+def test_next_page_request_follows_link_verbatim_with_accept_header():
+    _seed_ssm()
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        json={"hits": [_a_hit("a")], "nextSearchAfterResults": NEXT_URL},
+    )
+    responses.add(responses.GET, SEARCH_URL, json={"hits": []})
+
+    list(
+        _a_service().resource_search(
+            {"aggregation": "none"}, page_size=2, api_version="2099-01-01"
+        )
+    )
+
+    second_request = responses.calls[1].request
+    assert second_request.url == NEXT_URL
+    assert "version=2099-01-01" in second_request.headers["Accept"]
+
+
+@mock_aws
+@responses.activate
+def test_stops_when_next_link_missing_even_with_hits():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=1))
+
+    assert [hit["identifier"] for hit in hits] == ["a"]
+    assert len(responses.calls) == 1
+
+
+@mock_aws
+@responses.activate
+def test_empty_first_page_yields_nothing():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": []})
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}))
+
+    assert hits == []
+    assert len(responses.calls) == 1
+
+
+@mock_aws
+@responses.activate
+def test_client_error_stops_pagination():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"detail": "bad request"}, status=400)
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}))
+
+    assert hits == []
+    assert len(responses.calls) == 1
+
+
+@mock_aws
+@responses.activate
+def test_persistent_server_error_gives_up_and_yields_nothing(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={}, status=500)
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}))
+
+    assert hits == []
+    assert len(responses.calls) == 5

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -57,6 +57,17 @@ def test_first_request_uses_results_and_no_from_offset():
 
 @mock_aws
 @responses.activate
+def test_sends_identifying_user_agent():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    list(_a_service().resource_search({"aggregation": "none"}))
+
+    assert "nva-aws-cli-tools" in responses.calls[0].request.headers["User-Agent"]
+
+
+@mock_aws
+@responses.activate
 def test_follows_next_search_after_link_across_pages():
     _seed_ssm()
     responses.add(

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -121,6 +121,33 @@ def test_empty_first_page_yields_nothing():
 
 @mock_aws
 @responses.activate
+def test_reports_total_hits_once_from_first_page():
+    _seed_ssm()
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        json={
+            "hits": [_a_hit("a"), _a_hit("b")],
+            "totalHits": 42,
+            "nextSearchAfterResults": NEXT_URL,
+        },
+    )
+    responses.add(
+        responses.GET, SEARCH_URL, json={"hits": [_a_hit("c")], "totalHits": 42}
+    )
+
+    reported = []
+    list(
+        _a_service().resource_search(
+            {"aggregation": "none"}, page_size=2, on_total_hits=reported.append
+        )
+    )
+
+    assert reported == [42]
+
+
+@mock_aws
+@responses.activate
 def test_client_error_stops_pagination():
     _seed_ssm()
     responses.add(responses.GET, SEARCH_URL, json={"detail": "bad request"}, status=400)

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -64,7 +64,7 @@ def test_follows_next_search_after_link_across_pages():
         SEARCH_URL,
         json={"hits": [_a_hit("a"), _a_hit("b")], "nextSearchAfterResults": NEXT_URL},
     )
-    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("c")]})
+    responses.add(responses.GET, NEXT_URL, json={"hits": [_a_hit("c")]})
 
     hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=2))
 
@@ -82,7 +82,7 @@ def test_next_page_request_follows_link_verbatim_with_accept_header():
         SEARCH_URL,
         json={"hits": [_a_hit("a")], "nextSearchAfterResults": NEXT_URL},
     )
-    responses.add(responses.GET, SEARCH_URL, json={"hits": []})
+    responses.add(responses.GET, NEXT_URL, json={"hits": []})
 
     list(
         _a_service().resource_search(
@@ -133,7 +133,7 @@ def test_reports_total_hits_once_from_first_page():
         },
     )
     responses.add(
-        responses.GET, SEARCH_URL, json={"hits": [_a_hit("c")], "totalHits": 42}
+        responses.GET, NEXT_URL, json={"hits": [_a_hit("c")], "totalHits": 42}
     )
 
     reported = []

--- a/commands/tests/test_search_cli.py
+++ b/commands/tests/test_search_cli.py
@@ -72,9 +72,10 @@ def test_jsonl_sink_rotates_into_batches(tmp_path):
     assert sink.file_count == 3
     assert [os.path.basename(path) for path in sink.paths] == files
 
-    line_counts = [
-        sum(1 for _ in open(tmp_path / name, encoding="utf-8")) for name in files
-    ]
+    line_counts = []
+    for name in files:
+        with open(tmp_path / name, encoding="utf-8") as batch_file:
+            line_counts.append(sum(1 for _ in batch_file))
     assert line_counts == [1000, 1000, 500]
 
 

--- a/commands/tests/test_search_cli.py
+++ b/commands/tests/test_search_cli.py
@@ -1,0 +1,177 @@
+import glob
+import json
+import os
+
+import boto3
+import responses
+from click.testing import CliRunner
+from moto import mock_aws
+
+from commands.search import search, _JsonlSink, _format_hit_line
+from commands.utils import AppContext
+
+API_DOMAIN = "api.example.org"
+SEARCH_URL = f"https://{API_DOMAIN}/search/resources"
+A_PROFILE = "testprofile"
+A_UNIT = "194.0.0.0"
+
+
+def _ctx() -> AppContext:
+    return AppContext(
+        log_level=0,
+        profile=A_PROFILE,
+        session=boto3.Session(region_name="eu-west-1"),
+    )
+
+
+def _seed_ssm() -> None:
+    ssm = boto3.client("ssm", region_name="eu-west-1")
+    ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
+
+
+def _a_hit(identifier: str) -> dict:
+    return {"identifier": identifier, "type": "Publication"}
+
+
+def test_format_hit_line_id_only_returns_identifier():
+    assert _format_hit_line(_a_hit("abc"), id_only=True, compact=True) == "abc"
+
+
+def test_format_hit_line_id_only_missing_identifier_returns_none():
+    assert _format_hit_line({}, id_only=True, compact=True) is None
+
+
+def test_format_hit_line_compact_is_single_line_json():
+    line = _format_hit_line({"identifier": "abc", "x": 1}, id_only=False, compact=True)
+
+    assert "\n" not in line
+    assert json.loads(line) == {"identifier": "abc", "x": 1}
+
+
+def test_format_hit_line_pretty_is_indented():
+    line = _format_hit_line({"identifier": "abc"}, id_only=False, compact=False)
+
+    assert "\n" in line
+
+
+def test_jsonl_sink_rotates_into_batches(tmp_path):
+    base = str(tmp_path / "resultat.jsonl")
+
+    with _JsonlSink(base, batch_size=1000) as sink:
+        for index in range(2500):
+            sink.write(_format_hit_line(_a_hit(f"id-{index}"), False, True))
+
+    files = sorted(
+        os.path.basename(path) for path in glob.glob(str(tmp_path / "*.jsonl"))
+    )
+    assert files == [
+        "resultat_00001.jsonl",
+        "resultat_00002.jsonl",
+        "resultat_00003.jsonl",
+    ]
+    assert sink.file_count == 3
+    assert [os.path.basename(path) for path in sink.paths] == files
+
+    line_counts = [
+        sum(1 for _ in open(tmp_path / name, encoding="utf-8")) for name in files
+    ]
+    assert line_counts == [1000, 1000, 500]
+
+
+def test_jsonl_sink_stdout_mode_prints_and_writes_no_files(capsys):
+    with _JsonlSink(None, batch_size=1000) as sink:
+        sink.write('{"identifier": "a"}')
+
+    assert sink.file_count == 0
+    assert capsys.readouterr().out.strip() == '{"identifier": "a"}'
+
+
+@mock_aws
+@responses.activate
+def test_command_writes_batched_jsonl_files():
+    _seed_ssm()
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        json={"hits": [_a_hit("a"), _a_hit("b"), _a_hit("c")]},
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            search,
+            [
+                "resources",
+                "--unit",
+                A_UNIT,
+                "--output",
+                "out.jsonl",
+                "--batch-size",
+                "2",
+            ],
+            obj=_ctx(),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert sorted(glob.glob("*.jsonl")) == ["out_00001.jsonl", "out_00002.jsonl"]
+
+        first_batch = _read_lines("out_00001.jsonl")
+        second_batch = _read_lines("out_00002.jsonl")
+        assert len(first_batch) == 2
+        assert len(second_batch) == 1
+        assert json.loads(first_batch[0])["identifier"] == "a"
+        assert json.loads(second_batch[0])["identifier"] == "c"
+
+
+@mock_aws
+@responses.activate
+def test_command_uses_suffixed_filename_by_default():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            search,
+            ["resources", "--unit", A_UNIT, "--output", "out.jsonl"],
+            obj=_ctx(),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert glob.glob("*.jsonl") == ["out_00001.jsonl"]
+
+
+@mock_aws
+@responses.activate
+def test_command_id_only_prints_identifiers_to_stdout():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a"), _a_hit("b")]})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        search, ["resources", "--unit", A_UNIT, "--id-only"], obj=_ctx()
+    )
+
+    assert result.exit_code == 0, result.output
+    output_lines = [line for line in result.output.splitlines() if line.strip()]
+    assert "a" in output_lines
+    assert "b" in output_lines
+
+
+@mock_aws
+@responses.activate
+def test_command_default_prints_pretty_json_to_stdout():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    runner = CliRunner()
+    result = runner.invoke(search, ["resources", "--unit", A_UNIT], obj=_ctx())
+
+    assert result.exit_code == 0, result.output
+    assert '"identifier": "a"' in result.output
+    assert "{\n" in result.output
+
+
+def _read_lines(filename: str) -> list:
+    with open(filename, encoding="utf-8") as file:
+        return file.read().splitlines()

--- a/commands/tests/test_search_cli.py
+++ b/commands/tests/test_search_cli.py
@@ -78,6 +78,16 @@ def test_jsonl_sink_rotates_into_batches(tmp_path):
     assert line_counts == [1000, 1000, 500]
 
 
+def test_jsonl_sink_creates_missing_parent_directories(tmp_path):
+    base = str(tmp_path / "nested" / "dir" / "resultat.jsonl")
+
+    with _JsonlSink(base, batch_size=1000) as sink:
+        sink.write('{"identifier": "a"}')
+
+    assert os.path.isfile(tmp_path / "nested" / "dir" / "resultat_00001.jsonl")
+    assert sink.file_count == 1
+
+
 def test_jsonl_sink_stdout_mode_prints_and_writes_no_files(capsys):
     with _JsonlSink(None, batch_size=1000) as sink:
         sink.write('{"identifier": "a"}')
@@ -139,6 +149,24 @@ def test_command_uses_suffixed_filename_by_default():
 
         assert result.exit_code == 0, result.output
         assert glob.glob("*.jsonl") == ["out_00001.jsonl"]
+
+
+@mock_aws
+@responses.activate
+def test_command_creates_output_directory_when_missing():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            search,
+            ["resources", "--unit", A_UNIT, "--output", "exports/data/out.jsonl"],
+            obj=_ctx(),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert os.path.isfile("exports/data/out_00001.jsonl")
 
 
 @mock_aws


### PR DESCRIPTION
Adds a batched JSONL export to `search resources` and switches pagination to search-after so arbitrarily large result sets can be exported.

- Paginate `resources` by following the `nextSearchAfterResults` link instead of a `from`/`results` offset, removing the ~10k offset-window limit
- Add `--output` to write hits as JSONL, split into files of `--batch-size` (default 1000); logs the actual filenames written
- Add tests for search-after pagination and JSONL batching

https://sikt.atlassian.net/browse/NP-51369

Example:
```bash
uv run cli.py search resources \
  --aggregation none \
  --order modifiedDate \
  --sort desc \
  --query "categoryShould=OtherStudentWork,DegreeBachelor,DegreeMaster,DegreePhd,ArtisticDegreePhd,DegreeLicentiate" \
  --query "files=hasPublicFiles" \
  --output student_work_2026_07_01/batch.jsonl
```
