### PR TITLE
feat(search): adaptive page size with backoff and poison detection

### DIFF
--- a/commands/search.py
+++ b/commands/search.py
@@ -5,10 +5,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple
 
-from tqdm import tqdm
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 
 from commands.services.search_api import SearchApiService
 from commands.utils import AppContext
+from log_config import log_console
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +94,10 @@ def search(ctx: AppContext):
 @click.option(
     "--page-size",
     type=int,
-    default=50,
-    help="Number of results per page (default: 50)",
+    default=500,
+    help="Maximum results per page. The client starts low, ramps up toward this "
+    "while pages succeed, and backs off (down to 1) when the server fails a page "
+    "(default: 500)",
 )
 @click.option(
     "--limit",
@@ -153,7 +163,9 @@ def search(ctx: AppContext):
 @click.option(
     "--order",
     type=str,
-    help="Order field (e.g., modifiedDate, createdDate)",
+    help="Order field (e.g., modifiedDate, createdDate). For large exports prefer "
+    "an immutable field like createdDate; modifiedDate can cause updated records "
+    "to be skipped (see the command help for details)",
 )
 @click.option(
     "--sort",
@@ -186,10 +198,18 @@ def search(ctx: AppContext):
     help="Additional query parameters in format key=value (can be used multiple times)",
 )
 @click.option(
+    "--exclude-fields",
+    type=str,
+    multiple=True,
+    help="Top-level field(s) to drop from each hit (maps to nodesExcluded). "
+    "Comma-separated or repeated, e.g. --exclude-fields contributorsPreview,tags",
+)
+@click.option(
     "--api-version",
     type=str,
     default="2024-12-01",
-    help="API version to use (default: 2024-12-01)",
+    help="API version for the Accept header (default: 2024-12-01). Pass an empty "
+    'string (--api-version "") to omit the version and use the server default',
 )
 def resources(
     ctx: AppContext,
@@ -199,6 +219,7 @@ def resources(
     output: str | None,
     batch_size: int,
     query: Tuple[str, ...],
+    exclude_fields: Tuple[str, ...],
     api_version: str,
     **kwargs,
 ) -> None:
@@ -206,28 +227,46 @@ def resources(
 
     This command provides automatic pagination and supports all search API parameters.
 
+    Stable pagination (avoiding skipped records): search-after is only stable when
+    the sort key never changes for a document while you page. Sorting on
+    --order modifiedDate is unsafe for large exports, because an updated document
+    gets a new modifiedDate and moves past the cursor, so it is skipped. Prefer an
+    immutable field: --order createdDate never changes after creation, so existing
+    documents are never lost and new ones land at the end (picked up with
+    --sort asc). The API appends the unique 'identifier' as a tie-breaker, so equal
+    sort values between pages are already handled; duplicates may appear (e.g. docs
+    created during the run) but no existing record is dropped.
+
+    \b
+    Recommended for a full export:
+    uv run cli.py search resources --order createdDate --sort asc --output out.jsonl
+
+    \b
     Examples:
         # Search by unit and year range
         uv run cli.py search resources --unit 1965.0.0.0 --year-from 2025 --year-to 2026
-
+    \b
         # Search by project (limit to first 100 results)
         uv run cli.py search resources --project 2744839 --limit 100
-
+    \b
         # Search by funding source and identifier
         uv run cli.py search resources --funding-source NFR --funding-identifier 357438
-
+    \b
         # Search by publisher (output only IDs)
         uv run cli.py search resources --publisher 08DC24C9-B7FF-4192-89AC-C629D93AD9CF --id-only
-
+    \b
         # Write results to JSONL files, split into batches of 1000 (default)
         uv run cli.py search resources --unit 194.0.0.0 --output resultat.jsonl
         # -> resultat_00001.jsonl, resultat_00002.jsonl, ...
-
+    \b
         # Override the batch size
         uv run cli.py search resources --unit 194.0.0.0 --output resultat.jsonl --batch-size 500
-
+    \b
         # Use additional query parameters
         uv run cli.py search resources --query "funding=some-id" --query "status=published" --aggregation all
+    \b
+        # Drop heavy fields from each hit (nodesExcluded)
+        uv run cli.py search resources --exclude-fields contributorsPreview,tags --output out.jsonl
     """
     search_service = SearchApiService(session=ctx.session)
     search_params = SearchParams.from_kwargs(**kwargs)
@@ -240,45 +279,65 @@ def resources(
         else:
             logger.warning(f"Ignoring invalid query parameter: {q}")
 
-    compact = output is not None
-    progress_bar = None
+    excluded = _split_csv(exclude_fields)
+    if excluded:
+        query_params["nodesExcluded"] = ",".join(excluded)
 
-    def start_progress(total_hits: int) -> None:
-        nonlocal progress_bar
-        capped_total = min(total_hits, limit) if limit else total_hits
-        progress_bar = tqdm(
-            total=capped_total, unit="hit", desc="Fetching", disable=None
-        )
+    compact = output is not None
 
     try:
-        with _JsonlSink(output, batch_size) as sink:
-            count = 0
-            for hit in search_service.resource_search(
-                query_params,
-                page_size,
-                api_version=api_version,
-                on_total_hits=start_progress,
-            ):
-                if progress_bar is not None:
-                    progress_bar.update(1)
+        with Progress(*_progress_columns(), console=log_console) as progress:
+            task_id = None
 
-                line = _format_hit_line(hit, id_only, compact)
-                if line is not None:
-                    sink.write(line)
-                    count += 1
+            def start_progress(total_hits: int) -> None:
+                nonlocal task_id
+                capped_total = min(total_hits, limit) if limit else total_hits
+                task_id = progress.add_task("Fetching", total=capped_total)
 
-                if limit and count >= limit:
-                    break
+            with _JsonlSink(output, batch_size) as sink:
+                count = 0
+                for hit in search_service.resource_search(
+                    query_params,
+                    page_size,
+                    api_version=api_version,
+                    on_total_hits=start_progress,
+                ):
+                    if task_id is not None:
+                        progress.advance(task_id)
 
-            if count > 0:
-                _log_result_summary(count, output, batch_size, sink.paths)
+                    line = _format_hit_line(hit, id_only, compact)
+                    if line is not None:
+                        sink.write(line)
+                        count += 1
+
+                    if limit and count >= limit:
+                        break
+
+                if count > 0:
+                    _log_result_summary(count, output, batch_size, sink.paths)
 
     except Exception as e:
         logger.error(f"Error fetching resources: {e}")
         raise click.Abort()
-    finally:
-        if progress_bar is not None:
-            progress_bar.close()
+
+
+def _split_csv(values: Tuple[str, ...]) -> list:
+    items = []
+    for value in values:
+        items.extend(part.strip() for part in value.split(",") if part.strip())
+    return items
+
+
+def _progress_columns() -> tuple:
+    return (
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(complete_style="green", finished_style="green"),
+        MofNCompleteColumn(),
+        TextColumn("hits • elapsed"),
+        TimeElapsedColumn(),
+        TextColumn("• remaining"),
+        TimeRemainingColumn(),
+    )
 
 
 def _format_hit_line(hit: dict, id_only: bool, compact: bool) -> str | None:

--- a/commands/search.py
+++ b/commands/search.py
@@ -94,10 +94,10 @@ def search(ctx: AppContext):
 @click.option(
     "--page-size",
     type=int,
-    default=500,
+    default=300,
     help="Maximum results per page. The client starts low, ramps up toward this "
     "while pages succeed, and backs off (down to 1) when the server fails a page "
-    "(default: 500)",
+    "(default: 300)",
 )
 @click.option(
     "--limit",
@@ -321,7 +321,7 @@ def resources(
         raise click.Abort()
 
 
-def _split_csv(values: Tuple[str, ...]) -> list:
+def _split_csv(values: Tuple[str, ...]) -> list[str]:
     items = []
     for value in values:
         items.extend(part.strip() for part in value.split(",") if part.strip())

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -103,6 +103,14 @@ def _search_after_cursor(url: str) -> str | None:
     return None
 
 
+def _without_page_size_params(query_parameters: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: value
+        for key, value in query_parameters.items()
+        if key not in PAGE_SIZE_PARAMS
+    }
+
+
 def _accept_header(api_version: str | None) -> str:
     if api_version:
         return f"application/json; version={api_version}"
@@ -197,7 +205,8 @@ class SearchApiService:
         }
         page_size_control = AdaptivePageSize(maximum=page_size)
         url = self.get_uri("resources")
-        params = {**query_parameters, RESULTS_PARAM: page_size_control.current}
+        base_params = _without_page_size_params(query_parameters)
+        params = {**base_params, RESULTS_PARAM: page_size_control.current}
         total_reported = False
         last_identifier = None
 
@@ -241,11 +250,7 @@ class SearchApiService:
                 return outcome.data
 
             if not outcome.should_reduce_page_size:
-                logger.error(
-                    "Search failed with status %s and will not be retried: %s",
-                    outcome.status_code,
-                    outcome.error_body,
-                )
+                self._log_terminal_failure(outcome)
                 return None
 
             if not page_size_control.can_shrink():
@@ -268,9 +273,26 @@ class SearchApiService:
     def _apply_page_size(
         self, url: str, params: Dict[str, Any], page_size: int
     ) -> tuple[str, Dict[str, Any]]:
-        if RESULTS_PARAM in params:
-            return url, {**params, RESULTS_PARAM: page_size}
-        return _url_with_page_size(url, page_size), params
+        carried_keys = [param for param in PAGE_SIZE_PARAMS if param in params]
+        if not carried_keys:
+            return _url_with_page_size(url, page_size), params
+        updated = {**params, RESULTS_PARAM: page_size}
+        for param in carried_keys:
+            updated[param] = page_size
+        return url, updated
+
+    def _log_terminal_failure(self, outcome: SearchPageOutcome) -> None:
+        if outcome.status_code is None:
+            logger.error(
+                "Search failed due to a network error and will not be retried: %s",
+                outcome.error_body,
+            )
+        else:
+            logger.error(
+                "Search failed with status %s and will not be retried: %s",
+                outcome.status_code,
+                outcome.error_body,
+            )
 
     def _log_poison_diagnostics(
         self,
@@ -320,7 +342,7 @@ class SearchApiService:
             )
         except requests.exceptions.RequestException as e:
             logger.debug("Network error after retries: %s", e)
-            return SearchPageOutcome(should_reduce_page_size=True, error_body=str(e))
+            return SearchPageOutcome(should_reduce_page_size=False, error_body=str(e))
 
         if response.status_code != 200:
             logger.debug(

--- a/commands/services/search_api.py
+++ b/commands/services/search_api.py
@@ -1,17 +1,112 @@
 import boto3
+import json
 import logging
 import requests
+from dataclasses import dataclass
 from tenacity import (
     retry,
     stop_after_attempt,
-    wait_exponential,
+    wait_none,
     retry_if_exception_type,
 )
 from typing import Dict, Any, Callable, Generator
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
 USER_AGENT = "nva-aws-cli-tools (+https://github.com/BIBSYSDEV/nva-aws-cli-tools)"
+
+START_PAGE_SIZE = 50
+MIN_PAGE_SIZE = 1
+RAMP_UP_STEP = 50
+RAMP_UP_AFTER_SUCCESSES = 2
+
+NETWORK_RETRY_ATTEMPTS = 3
+
+RESULTS_PARAM = "results"
+PAGE_SIZE_PARAMS = ("results", "size")
+SEARCH_AFTER_PARAMS = ("search_after", "searchAfter")
+
+
+@dataclass
+class SearchPageOutcome:
+    data: Dict[str, Any] | None = None
+    should_reduce_page_size: bool = False
+    status_code: int | None = None
+    error_body: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.data is not None
+
+
+class AdaptivePageSize:
+    """Tunes the page size AIMD-style: shrink fast on failure, grow slowly on success.
+
+    On a failing page the size is halved toward ``minimum`` so we can isolate a
+    record the server chokes on. After a run of successful pages the size grows
+    additively back toward ``maximum``.
+    """
+
+    def __init__(
+        self,
+        maximum: int,
+        minimum: int = MIN_PAGE_SIZE,
+        start: int = START_PAGE_SIZE,
+        step: int = RAMP_UP_STEP,
+        successes_before_growth: int = RAMP_UP_AFTER_SUCCESSES,
+    ) -> None:
+        self._maximum = maximum
+        self._minimum = min(minimum, maximum)
+        self._step = step
+        self._successes_before_growth = successes_before_growth
+        self._current = self._clamp(start)
+        self._consecutive_successes = 0
+
+    @property
+    def current(self) -> int:
+        return self._current
+
+    def can_shrink(self) -> bool:
+        return self._current > self._minimum
+
+    def shrink(self) -> int:
+        self._current = max(self._minimum, self._current // 2)
+        self._consecutive_successes = 0
+        return self._current
+
+    def register_success(self) -> None:
+        self._consecutive_successes += 1
+        if self._consecutive_successes >= self._successes_before_growth:
+            self._current = min(self._maximum, self._current + self._step)
+            self._consecutive_successes = 0
+
+    def _clamp(self, value: int) -> int:
+        return max(self._minimum, min(self._maximum, value))
+
+
+def _url_with_page_size(url: str, page_size: int) -> str:
+    parsed = urlparse(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query[RESULTS_PARAM] = str(page_size)
+    for param in PAGE_SIZE_PARAMS:
+        if param in query:
+            query[param] = str(page_size)
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def _search_after_cursor(url: str) -> str | None:
+    query = dict(parse_qsl(urlparse(url).query, keep_blank_values=True))
+    for param in SEARCH_AFTER_PARAMS:
+        if param in query:
+            return query[param]
+    return None
+
+
+def _accept_header(api_version: str | None) -> str:
+    if api_version:
+        return f"application/json; version={api_version}"
+    return "application/json"
 
 
 class SearchApiService:
@@ -42,10 +137,10 @@ class SearchApiService:
         return any(handle_url.endswith(f"/{handle_value}") for handle_url in handles)
 
     @retry(
-        stop=stop_after_attempt(5),
-        wait=wait_exponential(multiplier=1, min=2, max=30),
+        stop=stop_after_attempt(NETWORK_RETRY_ATTEMPTS),
+        wait=wait_none(),
         retry=retry_if_exception_type(
-            (requests.exceptions.RequestException, requests.exceptions.HTTPError)
+            (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
         ),
         reraise=True,
     )
@@ -62,7 +157,7 @@ class SearchApiService:
         logger.debug(f"Full URL: {response.url}")
 
         if response.status_code >= 500:
-            logger.error(f"Server error {response.status_code}, will retry...")
+            logger.debug(f"Server error {response.status_code}; will reduce page size")
             response.raise_for_status()
 
         return response
@@ -81,9 +176,14 @@ class SearchApiService:
         response body instead of an incrementing ``from`` offset. This avoids the
         offset window limit and lets us page through arbitrarily large result sets.
 
+        The page size adapts as we go: it starts low, ramps up toward ``page_size``
+        while pages succeed, and backs off (down to a single record) when the
+        server fails a page, so a large page size cannot stall the whole export.
+
         Args:
             query_parameters: Dictionary of query parameters (without pagination keys)
-            page_size: Number of results per page (default: 100)
+            page_size: Maximum number of results per page; the client ramps up
+                toward this and backs off below it on failures (default: 100)
             api_version: API version to use in Accept header (default: 2024-12-01)
             on_total_hits: Optional callback invoked once with ``totalHits`` from
                 the first page, e.g. to size a progress bar
@@ -92,18 +192,19 @@ class SearchApiService:
             Individual hits from the search results
         """
         headers = {
-            "Accept": f"application/json; version={api_version}",
+            "Accept": _accept_header(api_version),
             "User-Agent": USER_AGENT,
         }
+        page_size_control = AdaptivePageSize(maximum=page_size)
         url = self.get_uri("resources")
-        params = {
-            **query_parameters,
-            "results": page_size,
-        }
+        params = {**query_parameters, RESULTS_PARAM: page_size_control.current}
         total_reported = False
+        last_identifier = None
 
         while url:
-            response_data = self._fetch_search_page(url, headers, params)
+            response_data = self._fetch_page_with_backoff(
+                url, headers, params, page_size_control, last_identifier
+            )
             if response_data is None:
                 break
 
@@ -116,39 +217,138 @@ class SearchApiService:
                 break
 
             yield from hits
+            last_identifier = hits[-1].get("identifier")
 
-            url = response_data.get(self.NEXT_PAGE_FIELD)
-            params = {}
+            next_url = response_data.get(self.NEXT_PAGE_FIELD)
+            if next_url:
+                url = _url_with_page_size(next_url, page_size_control.current)
+                params = {}
+            else:
+                url = None
+
+    def _fetch_page_with_backoff(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        page_size_control: AdaptivePageSize,
+        previous_identifier: str | None,
+    ) -> Dict[str, Any] | None:
+        while True:
+            outcome = self._fetch_search_page(url, headers, params)
+            if outcome.succeeded:
+                page_size_control.register_success()
+                return outcome.data
+
+            if not outcome.should_reduce_page_size:
+                logger.error(
+                    "Search failed with status %s and will not be retried: %s",
+                    outcome.status_code,
+                    outcome.error_body,
+                )
+                return None
+
+            if not page_size_control.can_shrink():
+                self._log_poison_diagnostics(
+                    url, outcome, page_size_control.current, previous_identifier
+                )
+                return None
+
+            failing_size = page_size_control.current
+            reduced = page_size_control.shrink()
+            logger.warning(
+                "Search failed with status %s at page size %d; "
+                "backing off to %d and retrying",
+                outcome.status_code,
+                failing_size,
+                reduced,
+            )
+            url, params = self._apply_page_size(url, params, reduced)
+
+    def _apply_page_size(
+        self, url: str, params: Dict[str, Any], page_size: int
+    ) -> tuple[str, Dict[str, Any]]:
+        if RESULTS_PARAM in params:
+            return url, {**params, RESULTS_PARAM: page_size}
+        return _url_with_page_size(url, page_size), params
+
+    def _log_poison_diagnostics(
+        self,
+        url: str,
+        outcome: SearchPageOutcome,
+        page_size: int,
+        previous_identifier: str | None,
+    ) -> None:
+        logger.error(
+            "Search still failing at page size %d (status %s) after backing off to "
+            "the minimum. A single poisoned record right after the current position "
+            "is the likely cause.",
+            page_size,
+            outcome.status_code,
+        )
+        logger.error("Failing request URL: %s", url)
+        cursor = _search_after_cursor(url)
+        if cursor is not None:
+            logger.error("search-after cursor at failure: %s", cursor)
+        if previous_identifier is not None:
+            logger.error(
+                "Last identifier fetched successfully before failure: %s "
+                "(the poisoned record is the next one in sort order)",
+                previous_identifier,
+            )
+        if outcome.error_body:
+            logger.error("Response body: %s", outcome.error_body)
 
     def _fetch_search_page(
         self,
         url: str,
         headers: Dict[str, str],
         params: Dict[str, Any],
-    ) -> Dict[str, Any] | None:
+    ) -> SearchPageOutcome:
         try:
             response = self._make_search_request(url, headers, params)
         except requests.exceptions.HTTPError as e:
-            logger.error(
-                f"Failed to search after retries. Status: {e.response.status_code}",
+            status = e.response.status_code if e.response is not None else None
+            body = self._error_body(e.response)
+            logger.debug(
+                "Search request failed after retries (status %s): %s", status, body
             )
-            if e.response.status_code >= 400:
-                try:
-                    error_detail = e.response.json()
-                    logger.error(f"Error detail: {error_detail}")
-                except ValueError:
-                    logger.error(f"Error detail: {e.response.text}")
-            return None
+            return SearchPageOutcome(
+                should_reduce_page_size=self._is_server_error(status),
+                status_code=status,
+                error_body=body,
+            )
         except requests.exceptions.RequestException as e:
-            logger.error(f"Network error after retries: {e}")
-            return None
+            logger.debug("Network error after retries: %s", e)
+            return SearchPageOutcome(should_reduce_page_size=True, error_body=str(e))
 
         if response.status_code != 200:
-            logger.error(f"Failed to search. {response.status_code}: {response.text}")
-            return None
+            logger.debug(
+                "Search returned status %s: %s", response.status_code, response.text
+            )
+            return SearchPageOutcome(
+                should_reduce_page_size=self._is_server_error(response.status_code),
+                status_code=response.status_code,
+                error_body=response.text,
+            )
 
         try:
-            return response.json()
+            return SearchPageOutcome(data=response.json())
         except ValueError:
-            logger.error(f"Search response was not valid JSON: {response.text}")
+            logger.debug("Search response was not valid JSON: %s", response.text)
+            return SearchPageOutcome(
+                status_code=response.status_code, error_body=response.text
+            )
+
+    @staticmethod
+    def _is_server_error(status_code: int | None) -> bool:
+        return status_code is not None and status_code >= 500
+
+    @staticmethod
+    def _error_body(response: requests.Response | None) -> str | None:
+        if response is None:
             return None
+        try:
+            return json.dumps(response.json())
+        except ValueError:
+            return response.text

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -1,10 +1,18 @@
 import urllib.parse
 
 import boto3
+import requests
 import responses
 from moto import mock_aws
+from responses import matchers
 
-from commands.services.search_api import SearchApiService
+from commands.services.search_api import (
+    AdaptivePageSize,
+    SearchApiService,
+    _accept_header,
+    _search_after_cursor,
+    _url_with_page_size,
+)
 
 API_DOMAIN = "api.example.org"
 SEARCH_URL = f"https://{API_DOMAIN}/search/resources"
@@ -68,6 +76,26 @@ def test_sends_identifying_user_agent():
 
 @mock_aws
 @responses.activate
+def test_empty_api_version_omits_version_from_accept_header():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    list(_a_service().resource_search({"aggregation": "none"}, api_version=""))
+
+    assert responses.calls[0].request.headers["Accept"] == "application/json"
+
+
+def test_accept_header_includes_version_when_set():
+    assert _accept_header("2024-12-01") == "application/json; version=2024-12-01"
+
+
+def test_accept_header_omits_version_when_empty():
+    assert _accept_header("") == "application/json"
+    assert _accept_header(None) == "application/json"
+
+
+@mock_aws
+@responses.activate
 def test_follows_next_search_after_link_across_pages():
     _seed_ssm()
     responses.add(
@@ -86,7 +114,7 @@ def test_follows_next_search_after_link_across_pages():
 
 @mock_aws
 @responses.activate
-def test_next_page_request_follows_link_verbatim_with_accept_header():
+def test_next_page_keeps_cursor_and_sets_current_page_size():
     _seed_ssm()
     responses.add(
         responses.GET,
@@ -102,7 +130,9 @@ def test_next_page_request_follows_link_verbatim_with_accept_header():
     )
 
     second_request = responses.calls[1].request
-    assert second_request.url == NEXT_URL
+    params = _query_params(responses.calls[1])
+    assert params["searchAfter"] == "next-cursor"
+    assert params["results"] == "2"
     assert "version=2099-01-01" in second_request.headers["Accept"]
 
 
@@ -183,12 +213,181 @@ def test_invalid_json_body_yields_nothing_without_crashing():
 
 @mock_aws
 @responses.activate
-def test_persistent_server_error_gives_up_and_yields_nothing(monkeypatch):
+def test_persistent_server_error_backs_off_to_minimum_then_gives_up(monkeypatch):
     monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
     _seed_ssm()
     responses.add(responses.GET, SEARCH_URL, json={}, status=500)
 
-    hits = list(_a_service().resource_search({"aggregation": "none"}))
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=2))
 
     assert hits == []
-    assert len(responses.calls) == 5
+    sizes_requested = {_query_params(call)["results"] for call in responses.calls}
+    assert sizes_requested == {"2", "1"}
+
+
+@mock_aws
+@responses.activate
+def test_server_error_is_not_retried_before_reducing_page_size(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={}, status=500)
+
+    list(_a_service().resource_search({"aggregation": "none"}, page_size=2))
+
+    assert len(responses.calls) == 2
+
+
+@mock_aws
+@responses.activate
+def test_network_errors_are_retried_before_giving_up(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(
+        responses.GET, SEARCH_URL, body=requests.exceptions.ConnectionError("boom")
+    )
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=1))
+
+    assert hits == []
+    assert len(responses.calls) == 3
+
+
+@mock_aws
+@responses.activate
+def test_server_error_reduces_page_size_and_recovers(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        match=[matchers.query_param_matcher({"results": "2"}, strict_match=False)],
+        json={},
+        status=500,
+    )
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        match=[matchers.query_param_matcher({"results": "1"}, strict_match=False)],
+        json={"hits": [_a_hit("a")]},
+    )
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=2))
+
+    assert [hit["identifier"] for hit in hits] == ["a"]
+
+
+@mock_aws
+@responses.activate
+def test_poison_diagnostics_logged_at_minimum_page_size(monkeypatch, caplog):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    poison_next = f"{SEARCH_URL}?search_after=poison-cursor&size=1"
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        match=[
+            matchers.query_param_matcher({"aggregation": "none"}, strict_match=False)
+        ],
+        json={"hits": [_a_hit("last-good")], "nextSearchAfterResults": poison_next},
+    )
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        match=[
+            matchers.query_param_matcher(
+                {"search_after": "poison-cursor"}, strict_match=False
+            )
+        ],
+        json={},
+        status=500,
+    )
+
+    with caplog.at_level("ERROR"):
+        hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=1))
+
+    assert [hit["identifier"] for hit in hits] == ["last-good"]
+    assert "poisoned record" in caplog.text
+    assert "poison-cursor" in caplog.text
+    assert "last-good" in caplog.text
+
+
+@mock_aws
+@responses.activate
+def test_client_error_does_not_trigger_page_size_backoff(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"detail": "bad request"}, status=400)
+
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=100))
+
+    assert hits == []
+    assert len(responses.calls) == 1
+
+
+def test_adaptive_page_size_ramps_up_additively_after_successes():
+    control = AdaptivePageSize(
+        maximum=500, start=50, step=50, successes_before_growth=2
+    )
+    assert control.current == 50
+    control.register_success()
+    assert control.current == 50
+    control.register_success()
+    assert control.current == 100
+
+
+def test_adaptive_page_size_halves_on_shrink_down_to_minimum():
+    control = AdaptivePageSize(maximum=64, start=64, minimum=1)
+    sizes = []
+    while control.can_shrink():
+        sizes.append(control.shrink())
+    assert sizes == [32, 16, 8, 4, 2, 1]
+    assert control.can_shrink() is False
+
+
+def test_adaptive_page_size_never_grows_past_maximum():
+    control = AdaptivePageSize(maximum=60, start=50, step=50, successes_before_growth=1)
+    control.register_success()
+    assert control.current == 60
+
+
+def test_adaptive_page_size_clamps_start_within_bounds():
+    control = AdaptivePageSize(maximum=10, start=50)
+    assert control.current == 10
+
+
+def test_shrink_resets_success_streak():
+    control = AdaptivePageSize(
+        maximum=500, start=50, step=50, successes_before_growth=2
+    )
+    control.register_success()
+    control.shrink()
+    control.register_success()
+    assert control.current == 25
+
+
+def test_url_with_page_size_overrides_both_size_and_results():
+    url = f"{SEARCH_URL}?search_after=abc%2Cdef&size=25&aggregation=none"
+
+    params = _query_params_from_url(_url_with_page_size(url, 5))
+
+    assert params["size"] == "5"
+    assert params["results"] == "5"
+    assert params["search_after"] == "abc,def"
+
+
+def test_url_with_page_size_adds_results_when_no_size_present():
+    params = _query_params_from_url(_url_with_page_size(f"{SEARCH_URL}?a=1", 3))
+
+    assert params["results"] == "3"
+    assert "size" not in params
+
+
+def test_search_after_cursor_reads_snake_case_and_camel_case():
+    assert _search_after_cursor(f"{SEARCH_URL}?search_after=snake") == "snake"
+    assert _search_after_cursor(f"{SEARCH_URL}?searchAfter=camel") == "camel"
+    assert _search_after_cursor(f"{SEARCH_URL}?other=1") is None
+
+
+def _query_params_from_url(url: str) -> dict:
+    query = urllib.parse.urlparse(url).query
+    return dict(urllib.parse.parse_qsl(query))

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -239,17 +239,52 @@ def test_server_error_is_not_retried_before_reducing_page_size(monkeypatch):
 
 @mock_aws
 @responses.activate
-def test_network_errors_are_retried_before_giving_up(monkeypatch):
+def test_network_errors_are_retried_by_count_without_page_size_backoff(monkeypatch):
     monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
     _seed_ssm()
     responses.add(
         responses.GET, SEARCH_URL, body=requests.exceptions.ConnectionError("boom")
     )
 
-    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=1))
+    hits = list(_a_service().resource_search({"aggregation": "none"}, page_size=5))
 
     assert hits == []
     assert len(responses.calls) == 3
+    sizes_requested = {_query_params(call)["results"] for call in responses.calls}
+    assert sizes_requested == {"5"}
+
+
+@mock_aws
+@responses.activate
+def test_network_error_is_terminal_without_poison_diagnostics(monkeypatch, caplog):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    _seed_ssm()
+    responses.add(
+        responses.GET, SEARCH_URL, body=requests.exceptions.ConnectionError("boom")
+    )
+
+    with caplog.at_level("ERROR"):
+        list(_a_service().resource_search({"aggregation": "none"}, page_size=5))
+
+    assert "poisoned record" not in caplog.text
+    assert "network error" in caplog.text
+
+
+@mock_aws
+@responses.activate
+def test_page_size_params_from_query_do_not_override_adaptive_control():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    list(
+        _a_service().resource_search(
+            {"aggregation": "none", "results": "999", "size": "999"}, page_size=25
+        )
+    )
+
+    params = _query_params(responses.calls[0])
+    assert params["results"] == "25"
+    assert "size" not in params
 
 
 @mock_aws

--- a/commands/tests/test_search_cli.py
+++ b/commands/tests/test_search_cli.py
@@ -1,13 +1,14 @@
 import glob
 import json
 import os
+import urllib.parse
 
 import boto3
 import responses
 from click.testing import CliRunner
 from moto import mock_aws
 
-from commands.search import search, _JsonlSink, _format_hit_line
+from commands.search import search, _JsonlSink, _format_hit_line, _split_csv
 from commands.utils import AppContext
 
 API_DOMAIN = "api.example.org"
@@ -132,6 +133,41 @@ def test_command_writes_batched_jsonl_files():
         assert len(second_batch) == 1
         assert json.loads(first_batch[0])["identifier"] == "a"
         assert json.loads(second_batch[0])["identifier"] == "c"
+
+
+@mock_aws
+@responses.activate
+def test_exclude_fields_sets_nodes_excluded_query_param():
+    _seed_ssm()
+    responses.add(responses.GET, SEARCH_URL, json={"hits": [_a_hit("a")]})
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            search,
+            [
+                "resources",
+                "--unit",
+                A_UNIT,
+                "--exclude-fields",
+                "contributorsPreview,tags",
+                "--exclude-fields",
+                "otherIdentifiers",
+                "--output",
+                "out.jsonl",
+            ],
+            obj=_ctx(),
+        )
+
+    assert result.exit_code == 0, result.output
+    query = urllib.parse.urlparse(responses.calls[0].request.url).query
+    params = dict(urllib.parse.parse_qsl(query))
+    assert params["nodesExcluded"] == "contributorsPreview,tags,otherIdentifiers"
+
+
+def test_split_csv_flattens_trims_and_drops_empty():
+    assert _split_csv(("a,b", " c ", "", "d")) == ["a", "b", "c", "d"]
+    assert _split_csv(()) == []
 
 
 @mock_aws


### PR DESCRIPTION
Makes `search resources` resilient to the server failing on large pages: the page size now adapts instead of being fixed, and when a single record keeps failing we pinpoint it in the log.

- Adaptive page size (AIMD): starts low, ramps up toward `--page-size` while pages succeed, and halves down to 1 on server errors so a large page size can't stall the export. `--page-size` is now the ceiling
- 500s are treated as a page-size signal (immediate back-off, no waiting between attempts); 4xx is terminal; only genuine network errors are retried
- Poison detection: when a record keeps failing at page size 1, logs the search-after cursor, last good identifier, status and body so it can be located in the index
- Follow link now overrides both `size` and `results`, and cursor logging reads snake_case `search_after`, to match the real API
- Rich progress bar (green, elapsed/remaining labels) replacing tqdm, sharing the console with logging
- `--exclude-fields` (nodesExcluded) to drop top-level fields from each hit
- Empty `--api-version` omits the version from the Accept header
- Command help documents stable-pagination sorting guidance

https://sikt.atlassian.net/browse/NP-51369