### PR TITLE
feat: Expand  command

### DIFF
--- a/commands/services/sqs.py
+++ b/commands/services/sqs.py
@@ -4,6 +4,7 @@ import re
 import signal
 import threading
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -54,6 +55,32 @@ EXCEPTION_CONTEXT_PATTERNS = [
     re.compile(r"([A-Z]\w*(?:Exception|Error)):\s*([^\n]{1,200})"),
     re.compile(r"Caused by:\s*([^:\n]+):\s*([^\n]{1,200})"),
 ]
+
+
+@dataclass(frozen=True)
+class QueueMessageCounts:
+    name: str
+    url: str
+    messages_available: int
+    messages_in_flight: int
+
+    @property
+    def has_messages(self) -> bool:
+        return self.messages_available > 0 or self.messages_in_flight > 0
+
+    @property
+    def total_messages(self) -> int:
+        return self.messages_available + self.messages_in_flight
+
+
+@dataclass(frozen=True)
+class QueueListing:
+    queues: List[QueueMessageCounts]
+    hidden_empty_count: int
+
+    @property
+    def total_queue_count(self) -> int:
+        return len(self.queues) + self.hidden_empty_count
 
 
 class SqsService:
@@ -109,6 +136,53 @@ class SqsService:
         except ClientError as e:
             logger.error(f"Error listing queues: {e}")
             raise e
+
+    def list_queue_message_counts(
+        self, name_filter: Optional[str] = None, include_empty: bool = False
+    ) -> QueueListing:
+        queue_urls = self._list_queue_urls(name_filter)
+        counts = [self._get_queue_message_counts(url) for url in queue_urls]
+        counts.sort(key=lambda queue: (-queue.total_messages, queue.name))
+
+        if include_empty:
+            return QueueListing(queues=counts, hidden_empty_count=0)
+
+        non_empty = [queue for queue in counts if queue.has_messages]
+        return QueueListing(
+            queues=non_empty, hidden_empty_count=len(counts) - len(non_empty)
+        )
+
+    def _list_queue_urls(self, name_filter: Optional[str] = None) -> List[str]:
+        paginator = self.sqs_client.get_paginator("list_queues")
+        queue_urls: List[str] = []
+        for page in paginator.paginate():
+            queue_urls.extend(page.get("QueueUrls", []))
+
+        if name_filter:
+            queue_urls = [
+                url
+                for url in queue_urls
+                if name_filter.lower() in url.split("/")[-1].lower()
+            ]
+        return queue_urls
+
+    def _get_queue_message_counts(self, queue_url: str) -> QueueMessageCounts:
+        response = self.sqs_client.get_queue_attributes(
+            QueueUrl=queue_url,
+            AttributeNames=[
+                "ApproximateNumberOfMessages",
+                "ApproximateNumberOfMessagesNotVisible",
+            ],
+        )
+        attributes = response.get("Attributes", {})
+        return QueueMessageCounts(
+            name=queue_url.split("/")[-1],
+            url=queue_url,
+            messages_available=int(attributes.get("ApproximateNumberOfMessages", 0)),
+            messages_in_flight=int(
+                attributes.get("ApproximateNumberOfMessagesNotVisible", 0)
+            ),
+        )
 
     def get_queue_attributes(self, queue_url: str) -> Dict[str, Any]:
         try:

--- a/commands/sqs.py
+++ b/commands/sqs.py
@@ -2,16 +2,17 @@ import click
 import json
 from rich.console import Console
 from rich.prompt import Confirm
+from rich.table import Table
 
 from commands.utils import AppContext
-from commands.services.sqs import SqsService
+from commands.services.sqs import QueueListing, QueueMessageCounts, SqsService
 
 console = Console()
 
 
 @click.group()
 @click.pass_obj
-def sqs(ctx: AppContext):
+def sqs(ctx: AppContext) -> None:
     """Manage SQS queues and messages."""
     pass
 
@@ -39,8 +40,14 @@ def sqs(ctx: AppContext):
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.pass_obj
 def drain(
-    ctx: AppContext, queue_name, output_dir, messages_per_file, delete, threads, yes
-):
+    ctx: AppContext,
+    queue_name: str,
+    output_dir: str | None,
+    messages_per_file: int,
+    delete: bool,
+    threads: int,
+    yes: bool,
+) -> None:
     sqs_service = SqsService(session=ctx.session)
 
     queue_url = get_queue_url(sqs_service, queue_name)
@@ -77,7 +84,7 @@ def drain(
 @sqs.command()
 @click.argument("queue_name", type=str)
 @click.pass_obj
-def info(ctx: AppContext, queue_name):
+def info(ctx: AppContext, queue_name: str) -> None:
     sqs_service = SqsService(session=ctx.session)
 
     queue_url = get_queue_url(sqs_service, queue_name)
@@ -87,7 +94,7 @@ def info(ctx: AppContext, queue_name):
 @sqs.command()
 @click.argument("folder_path", type=str)
 @click.pass_obj
-def analyze(ctx: AppContext, folder_path):
+def analyze(ctx: AppContext, folder_path: str) -> None:
     """Analyze messages from drained SQS queue JSONL files.
 
     This command analyzes the JSONL files created by the drain command to find:
@@ -107,35 +114,29 @@ def analyze(ctx: AppContext, folder_path):
 
 @sqs.command()
 @click.option("--filter", type=str, help="Filter queues by name pattern")
+@click.option(
+    "--include-empty",
+    is_flag=True,
+    help="Include queues with no messages available or in flight",
+)
 @click.pass_obj
-def list(ctx: AppContext, filter):
-    """List all SQS queues in the account."""
+def list(ctx: AppContext, filter: str | None, include_empty: bool) -> None:
+    """List SQS queues with message counts.
+
+    By default only queues with messages available or in flight are shown.
+    Use --include-empty to show all queues.
+    """
     sqs_service = SqsService(session=ctx.session)
 
     try:
-        response = sqs_service.sqs_client.list_queues()
-        queue_urls = response.get("QueueUrls", [])
-
-        if not queue_urls:
-            console.print("[yellow]No queues found[/yellow]")
-            return
-
-        if filter:
-            queue_urls = [url for url in queue_urls if filter.lower() in url.lower()]
-
-        console.print(
-            f"\n[bold cyan]SQS Queues ({sqs_service.profile} profile):[/bold cyan]\n"
+        listing = sqs_service.list_queue_message_counts(
+            name_filter=filter, include_empty=include_empty
         )
-
-        for url in sorted(queue_urls):
-            queue_name = url.split("/")[-1]
-            console.print(f"  • {queue_name}")
-
-        console.print(f"\n[dim]Total: {len(queue_urls)} queue(s)[/dim]")
-
     except Exception as e:
         console.print(f"[red]Error listing queues: {e}[/red]")
         raise click.Abort()
+
+    show_queue_listing(listing, sqs_service.profile)
 
 
 @sqs.command()
@@ -144,7 +145,7 @@ def list(ctx: AppContext, filter):
     "--max-messages", "-m", type=int, default=1000, help="Max messages to process"
 )
 @click.pass_obj
-def delete_duplicates(ctx: AppContext, queue_name: str, max_messages: int):
+def delete_duplicates(ctx: AppContext, queue_name: str, max_messages: int) -> None:
     sqs_service = SqsService(session=ctx.session)
     queue_url = get_queue_url(sqs_service, queue_name)
 
@@ -170,7 +171,7 @@ def delete_duplicates(ctx: AppContext, queue_name: str, max_messages: int):
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.pass_obj
-def redrive(ctx: AppContext, queue_name: str, destination: str, yes: bool):
+def redrive(ctx: AppContext, queue_name: str, destination: str, yes: bool) -> None:
     """Start a DLQ redrive, moving messages from source to destination queue."""
     sqs_service = SqsService(session=ctx.session)
 
@@ -191,7 +192,44 @@ def redrive(ctx: AppContext, queue_name: str, destination: str, yes: bool):
     console.print("[green]Redrive started[/green]")
 
 
-def show_queue_summary(sqs_service: SqsService, queue_url: str):
+def show_queue_listing(listing: QueueListing, profile: str) -> None:
+    if listing.total_queue_count == 0:
+        console.print("[yellow]No queues found[/yellow]")
+    elif not listing.queues:
+        console.print(
+            f"[yellow]No queues with messages ({listing.hidden_empty_count} empty "
+            f"queue(s) hidden, use --include-empty to show them)[/yellow]"
+        )
+    else:
+        console.print(build_queue_counts_table(listing.queues, profile))
+        console.print(f"[dim]{format_queue_listing_summary(listing)}[/dim]")
+
+
+def build_queue_counts_table(queues: list[QueueMessageCounts], profile: str) -> Table:
+    table = Table(title=f"SQS Queues ({profile} profile)")
+    table.add_column("Queue Name", style="cyan", no_wrap=True)
+    table.add_column("Messages Available", style="yellow", justify="right")
+    table.add_column("Messages In Flight", style="magenta", justify="right")
+
+    for queue in queues:
+        table.add_row(
+            queue.name,
+            str(queue.messages_available),
+            str(queue.messages_in_flight),
+        )
+    return table
+
+
+def format_queue_listing_summary(listing: QueueListing) -> str:
+    summary = f"Total: {len(listing.queues)} queue(s)"
+    if listing.hidden_empty_count > 0:
+        summary += (
+            f" ({listing.hidden_empty_count} empty hidden, use --include-empty to show)"
+        )
+    return summary
+
+
+def show_queue_summary(sqs_service: SqsService, queue_url: str) -> None:
     queue_full_name = queue_url.split("/")[-1]
     attrs = sqs_service.get_queue_attributes(queue_url)
 
@@ -211,7 +249,7 @@ def show_queue_summary(sqs_service: SqsService, queue_url: str):
     )
 
 
-def show_queue_details(sqs_service: SqsService, queue_url: str):
+def show_queue_details(sqs_service: SqsService, queue_url: str) -> None:
     show_queue_summary(sqs_service, queue_url)
 
     attrs = sqs_service.get_queue_attributes(queue_url)

--- a/commands/tests/test_sqs_list_cli.py
+++ b/commands/tests/test_sqs_list_cli.py
@@ -1,0 +1,92 @@
+import boto3
+from click.testing import CliRunner
+from moto import mock_aws
+
+from cli import cli
+
+
+def _create_queue(name: str, message_count: int = 0) -> str:
+    sqs = boto3.client("sqs")
+    queue_url = sqs.create_queue(QueueName=name)["QueueUrl"]
+    for index in range(message_count):
+        sqs.send_message(QueueUrl=queue_url, MessageBody=f"message-{index}")
+    return queue_url
+
+
+def _table_row(output: str, queue_name: str) -> list[str]:
+    matching_lines = [line for line in output.splitlines() if queue_name in line]
+    assert matching_lines, f"No table row for '{queue_name}' in output:\n{output}"
+    cells = [cell.strip() for cell in matching_lines[0].split("│")]
+    return [cell for cell in cells if cell]
+
+
+@mock_aws
+def test_list_shows_only_queues_with_messages_by_default():
+    _create_queue("busy-queue", message_count=3)
+    _create_queue("empty-queue")
+
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list"])
+
+    assert result.exit_code == 0, result.exception
+    assert "busy-queue" in result.output
+    assert "empty-queue" not in result.output
+    assert "1 empty hidden" in result.output
+
+    row = _table_row(result.output, "busy-queue")
+    assert row == ["busy-queue", "3", "0"]
+
+
+@mock_aws
+def test_list_include_empty_shows_all_queues():
+    _create_queue("busy-queue", message_count=2)
+    _create_queue("empty-queue")
+
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list", "--include-empty"])
+
+    assert result.exit_code == 0, result.exception
+    assert _table_row(result.output, "busy-queue") == ["busy-queue", "2", "0"]
+    assert _table_row(result.output, "empty-queue") == ["empty-queue", "0", "0"]
+    assert "Total: 2 queue(s)" in result.output
+
+
+@mock_aws
+def test_list_reports_messages_in_flight():
+    queue_url = _create_queue("inflight-queue", message_count=2)
+    boto3.client("sqs").receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1)
+
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list"])
+
+    assert result.exit_code == 0, result.exception
+    assert _table_row(result.output, "inflight-queue") == ["inflight-queue", "1", "1"]
+
+
+@mock_aws
+def test_list_filter_matches_queue_names():
+    _create_queue("orders-dlq", message_count=1)
+    _create_queue("payments-dlq", message_count=1)
+
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list", "--filter", "orders"])
+
+    assert result.exit_code == 0, result.exception
+    assert "orders-dlq" in result.output
+    assert "payments-dlq" not in result.output
+    assert "Total: 1 queue(s)" in result.output
+
+
+@mock_aws
+def test_list_reports_when_all_queues_are_empty():
+    _create_queue("empty-queue")
+
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list"])
+
+    assert result.exit_code == 0, result.exception
+    assert "No queues with messages" in result.output
+    assert "--include-empty" in result.output
+
+
+@mock_aws
+def test_list_reports_when_no_queues_exist():
+    result = CliRunner().invoke(cli, ["--quiet", "sqs", "list"])
+
+    assert result.exit_code == 0, result.exception
+    assert "No queues found" in result.output


### PR DESCRIPTION
Expands the `sqs list` command to show message counts per queue, and by default only show queues that are not empty.

Example usage:

```
# See all non-empty queues in account
uv run cli.py --profile nva-test sqs list

# See all queues in account
uv run cli.py --profile nva-test sqs list --include-empty
```