### PR TITLE
feat: Add typechecking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Formatting
         run: uv run ruff format --check .
+
+      - name: Typechecking
+        run: uv run ty check

--- a/commands/organization_migration.py
+++ b/commands/organization_migration.py
@@ -34,7 +34,7 @@ def organization_migration(ctx: AppContext):
 @click.pass_obj
 def list_publications(
     ctx: AppContext, organization_identifier: str, filename: str
-) -> dict:
+) -> None:
     service = SearchApiService(ctx.session)
     params = {"unit": organization_identifier}
     contributors_response = fetch_all(service, params)
@@ -62,7 +62,7 @@ def update_publications(
     old_organization_identifier: str,
     new_organization_identifier: str,
     filename: str,
-) -> dict:
+) -> None:
     with open(filename, "r") as file:
         report = json.load(file)
 
@@ -131,5 +131,5 @@ def fetch_all(service, params) -> list:
     return list(identifiers)
 
 
-def format(contributors_response, owner_response) -> str:
+def format(contributors_response, owner_response) -> dict:
     return {"contributors": contributors_response, "owners": owner_response}

--- a/commands/search.py
+++ b/commands/search.py
@@ -2,7 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import ClassVar, Self
+from typing import ClassVar, Self, TextIO
 
 import click
 from rich.progress import (
@@ -365,8 +365,8 @@ class _JsonlSink:
     def __init__(self, output: str | None, batch_size: int) -> None:
         self._output = output
         self._batch_size = batch_size
-        self._file = None
-        self._paths = []
+        self._file: TextIO | None = None
+        self._paths: list[str] = []
         self._lines_in_batch = 0
 
     def __enter__(self) -> Self:
@@ -389,14 +389,15 @@ class _JsonlSink:
             print(line)
             return
 
-        if self._file is None or self._lines_in_batch >= self._batch_size:
-            self._open_next_file()
+        file = self._file
+        if file is None or self._lines_in_batch >= self._batch_size:
+            file = self._open_next_file()
 
-        self._file.write(line)
-        self._file.write("\n")
+        file.write(line)
+        file.write("\n")
         self._lines_in_batch += 1
 
-    def _open_next_file(self) -> None:
+    def _open_next_file(self) -> TextIO:
         self._close_current_file()
         path = self._batch_path()
         self._paths.append(path)
@@ -404,8 +405,11 @@ class _JsonlSink:
         # Handle stays open across write() calls, closed by _close_current_file.
         self._file = open(path, "w", encoding="utf-8")  # noqa: SIM115
         self._lines_in_batch = 0
+        return self._file
 
     def _batch_path(self) -> str:
+        if self._output is None:
+            raise ValueError("Cannot write batch files without an output path")
         next_index = len(self._paths) + 1
         path = Path(self._output)
         return str(path.with_name(f"{path.stem}_{next_index:05d}{path.suffix}"))

--- a/commands/services/cognito_api.py
+++ b/commands/services/cognito_api.py
@@ -1,9 +1,12 @@
 import boto3
+from mypy_boto3_cognito_idp.type_defs import UserTypeTypeDef
 
 USER_POOL_ID_PARAMETER = "CognitoUserPoolId"
 
 
-def search_users(session: boto3.Session, search_term: str) -> list[dict] | None:
+def search_users(
+    session: boto3.Session, search_term: str
+) -> list[UserTypeTypeDef] | None:
     user_pool_id = _get_user_pool_id(session)
     users = _list_all_users(session, user_pool_id)
     return _filter_by_attribute_value(users, search_term)
@@ -15,9 +18,9 @@ def _get_user_pool_id(session: boto3.Session) -> str:
     return response["Parameter"]["Value"]
 
 
-def _list_all_users(session: boto3.Session, user_pool_id: str) -> list[dict]:
+def _list_all_users(session: boto3.Session, user_pool_id: str) -> list[UserTypeTypeDef]:
     cognito = session.client("cognito-idp")
-    users: list[dict] = []
+    users: list[UserTypeTypeDef] = []
     pagination_token: str | None = None
     while True:
         kwargs: dict = {"UserPoolId": user_pool_id}
@@ -31,8 +34,8 @@ def _list_all_users(session: boto3.Session, user_pool_id: str) -> list[dict]:
 
 
 def _filter_by_attribute_value(
-    users: list[dict], search_term: str
-) -> list[dict] | None:
+    users: list[UserTypeTypeDef], search_term: str
+) -> list[UserTypeTypeDef] | None:
     search_words = search_term.split()
     matches = [
         user

--- a/commands/services/dlq.py
+++ b/commands/services/dlq.py
@@ -1,15 +1,16 @@
 import logging
 from collections import defaultdict
+from typing import Any
 
 from botocore.exceptions import BotoCoreError, ClientError
 
 logger = logging.getLogger(__name__)
 
 
-def get_messages(sqs_client, queue: str, max_count: int) -> list[dict[str, any]]:
+def get_messages(sqs_client, queue: str, max_count: int) -> list[dict[str, Any]]:
     """Read messages from queue."""
     logger.info("Reading messages from the queue...")
-    all_messages: list[dict[str, any]] = []
+    all_messages: list[dict[str, Any]] = []
     seen_message_ids: set[str] = set()
 
     while len(all_messages) < max_count:
@@ -41,8 +42,12 @@ def get_messages(sqs_client, queue: str, max_count: int) -> list[dict[str, any]]
 
 def summarize_messages(messages: list[dict]) -> tuple[dict, dict]:
     """Summarize messages, grouped by sender and by body. Return JSON-serializable dicts."""
-    by_sender = defaultdict(lambda: {"count": 0, "candidates": set()})
-    by_body = defaultdict(lambda: {"count": 0, "candidates": set()})
+    by_sender: defaultdict[str, dict[str, Any]] = defaultdict(
+        lambda: {"count": 0, "candidates": set()}
+    )
+    by_body: defaultdict[str, dict[str, Any]] = defaultdict(
+        lambda: {"count": 0, "candidates": set()}
+    )
 
     for msg in messages:
         sender_id = msg.get("Attributes", {}).get("SenderId", "Unknown")

--- a/commands/services/dynamodb_exporter.py
+++ b/commands/services/dynamodb_exporter.py
@@ -21,18 +21,18 @@ logger = logging.getLogger(__name__)
 
 
 class DynamoDBEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, Decimal):
-            return float(obj) if obj % 1 else int(obj)
-        if isinstance(obj, Binary):
-            return base64.b64encode(bytes(obj)).decode("utf-8")
-        if isinstance(obj, bytes):
-            return base64.b64encode(obj).decode("utf-8")
-        if isinstance(obj, (datetime, date)):
-            return obj.isoformat()
-        if isinstance(obj, set):
-            return list(obj)
-        return super().default(obj)
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Decimal):
+            return float(o) if o % 1 else int(o)
+        if isinstance(o, Binary):
+            return base64.b64encode(bytes(o)).decode("utf-8")
+        if isinstance(o, bytes):
+            return base64.b64encode(o).decode("utf-8")
+        if isinstance(o, (datetime, date)):
+            return o.isoformat()
+        if isinstance(o, set):
+            return list(o)
+        return super().default(o)
 
 
 class GenericDynamodbExporter:

--- a/commands/services/lambda_api.py
+++ b/commands/services/lambda_api.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import boto3
+from mypy_boto3_lambda.type_defs import InvocationResponseTypeDef
 
 from commands.services.aws_utils import get_account_alias
 
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def invoke_function(
     session: boto3.Session, function_name: str, payload: str | None = None
-) -> dict:
+) -> InvocationResponseTypeDef:
     args: dict = {"FunctionName": function_name, "InvocationType": "Event"}
     if payload:
         args["Payload"] = payload

--- a/commands/services/pipelines.py
+++ b/commands/services/pipelines.py
@@ -117,7 +117,7 @@ def get_git_details(summary: dict) -> tuple[str, str]:
     return "Unknown", "Unknown"
 
 
-def get_source_details(stage_state: dict) -> tuple[str, str]:
+def get_source_details(stage_state: dict) -> tuple[str | None, str | None]:
     """
     Extracts the source information (branch/repo) from the source stage.
     """
@@ -136,13 +136,13 @@ def get_source_details(stage_state: dict) -> tuple[str, str]:
 
 def get_details_from_pipeline_execution(
     pipeline_runs: dict,
-) -> ExecutionDetails | None:
+) -> ExecutionDetails:
     """
     Extracts the execution details from a pipeline summary.
     """
     executions = pipeline_runs.get("pipelineExecutionSummaries", [])
     if not len(executions) > 0:
-        return None
+        return ExecutionDetails(execution_id="Unknown")
 
     pipeline_summary = executions[0]
     execution_id = pipeline_summary.get("pipelineExecutionId")

--- a/commands/services/resource.py
+++ b/commands/services/resource.py
@@ -8,7 +8,7 @@ class Resource:
     def __init__(self, data: dict):
         self.data = data
 
-    def identifier(self) -> str:
+    def identifier(self) -> str | None:
         return self.data.get("identifier", None)
 
     def migrate_contributor_affiliations(

--- a/commands/services/resource_batch_job.py
+++ b/commands/services/resource_batch_job.py
@@ -3,13 +3,15 @@ import logging
 import os
 import re
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
 from threading import Lock
+from typing import Any
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
+from mypy_boto3_sqs.type_defs import SendMessageBatchRequestEntryTypeDef
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ class ResourceBatchJobService:
     def __init__(self, session: boto3.Session):
         self.session = session
         self.sqs = self.session.client("sqs")
-        self._queue_url = None
+        self._queue_url: str | None = None
         self._find_batch_job_queue()
 
     def _find_batch_job_queue(self) -> None:
@@ -72,10 +74,10 @@ class ResourceBatchJobService:
 
     def _send_batch(
         self, messages: list[dict], queue_url: str
-    ) -> tuple[int, int, list[dict]]:
+    ) -> tuple[int, int, Sequence[Mapping[str, Any]]]:
         try:
             # Format messages for SQS batch send
-            sqs_messages = [
+            sqs_messages: list[SendMessageBatchRequestEntryTypeDef] = [
                 {"Id": str(i), "MessageBody": json.dumps(msg)}
                 for i, msg in enumerate(messages)
             ]
@@ -103,7 +105,8 @@ class ResourceBatchJobService:
         concurrency: int = 3,
     ) -> dict:
         # Check if queue was found during initialization
-        if not self._queue_url:
+        queue_url = self._queue_url
+        if not queue_url:
             return {
                 "success": False,
                 "error": "No DynamodbResourceBatchJobWorkQueue found",
@@ -145,7 +148,7 @@ class ResourceBatchJobService:
         def send_batch_wrapper(batch_data):
             """Wrapper to send a batch and handle results."""
             _, messages = batch_data  # batch_num not needed currently
-            successful, failed, failures = self._send_batch(messages, self._queue_url)
+            successful, failed, failures = self._send_batch(messages, queue_url)
 
             with lock:
                 nonlocal total_sent, failed_count
@@ -196,7 +199,7 @@ class ResourceBatchJobService:
             return False
 
         # Check format (only lowercase letters, numbers, and hyphens)
-        return re.match(r"^[a-z0-9-]+$", publication_id)
+        return re.match(r"^[a-z0-9-]+$", publication_id) is not None
 
     def _resolve_input_source(self, input_source: str) -> tuple[str, int, bool]:
         # Check if input_source is a file

--- a/commands/services/sqs.py
+++ b/commands/services/sqs.py
@@ -4,6 +4,7 @@ import re
 import signal
 import threading
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -11,6 +12,11 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
+from mypy_boto3_sqs.literals import QueueAttributeNameType
+from mypy_boto3_sqs.type_defs import (
+    DeleteMessageBatchRequestEntryTypeDef,
+    MessageTypeDef,
+)
 from rich.console import Console
 from rich.progress import (
     BarColumn,
@@ -193,7 +199,7 @@ class SqsService:
             ),
         )
 
-    def get_queue_attributes(self, queue_url: str) -> dict[str, Any]:
+    def get_queue_attributes(self, queue_url: str) -> dict[QueueAttributeNameType, str]:
         try:
             response = self.sqs_client.get_queue_attributes(
                 QueueUrl=queue_url, AttributeNames=["All"]
@@ -204,10 +210,8 @@ class SqsService:
             raise
 
     def start_redrive(self, source_queue_url: str, destination_queue_url: str) -> str:
-        source_arn = self.get_queue_attributes(source_queue_url).get("QueueArn")
-        destination_arn = self.get_queue_attributes(destination_queue_url).get(
-            "QueueArn"
-        )
+        source_arn = self.get_queue_attributes(source_queue_url)["QueueArn"]
+        destination_arn = self.get_queue_attributes(destination_queue_url)["QueueArn"]
 
         response = self.sqs_client.start_message_move_task(
             SourceArn=source_arn,
@@ -264,7 +268,7 @@ class SqsService:
         deleted_count = 0
         for i in range(0, len(receipt_handles), 10):
             batch = receipt_handles[i : i + 10]
-            entries = [
+            entries: list[DeleteMessageBatchRequestEntryTypeDef] = [
                 {"Id": str(j), "ReceiptHandle": handle}
                 for j, handle in enumerate(batch)
             ]
@@ -473,7 +477,7 @@ class SqsService:
             )
         )
 
-        stats = {
+        stats: dict[str, Any] = {
             "received": 0,
             "written": 0,
             "deleted": 0,
@@ -766,7 +770,7 @@ class SqsService:
         attribute_keys = Counter()
         message_attribute_keys = Counter()
         common_patterns = defaultdict(int)
-        stack_traces = []
+        stack_traces: list[dict[str, Any]] = []
         exception_contexts = Counter()
         identifier_counts: dict[str, int] = defaultdict(int)
 
@@ -1220,7 +1224,7 @@ class SqsService:
 
     def _process_message(
         self,
-        message: dict,
+        message: MessageTypeDef,
         id_to_message_id: dict,
         counts: dict[str, int],
         queue_url: str,
@@ -1281,7 +1285,7 @@ class SqsService:
         console.print(table)
 
 
-def find_identifier(message: dict[str, Any]) -> tuple[str, str] | None:
+def find_identifier(message: Mapping[str, Any]) -> tuple[str | None, str | None]:
     """
     Extract the first identifier found in message attributes.
 
@@ -1293,7 +1297,7 @@ def find_identifier(message: dict[str, Any]) -> tuple[str, str] | None:
 
     Returns:
         A tuple of (field_name, identifier_value) if an identifier is found,
-        or None if no identifier fields are present
+        or (None, None) if no identifier fields are present
     """
     # Define possible identifier field names in priority order
     identifier_fields = [

--- a/commands/services/tests/test_channels.py
+++ b/commands/services/tests/test_channels.py
@@ -31,6 +31,12 @@ def _ctx() -> AppContext:
     )
 
 
+def _request_json(call: responses.Call) -> dict:
+    request_body = call.request.body
+    assert isinstance(request_body, (str, bytes))
+    return json.loads(request_body)
+
+
 def _seed_aws() -> None:
     ssm = boto3.client("ssm", region_name="eu-west-1")
     ssm.put_parameter(Name="/NVA/ApiDomain", Value=API_DOMAIN, Type="String")
@@ -115,7 +121,7 @@ def test_search_with_kind_publisher_only_calls_publisher_endpoint():
     assert result.exit_code == 0, result.output
     get_calls = [c for c in responses.calls if c.request.method == "GET"]
     assert len(get_calls) == 1
-    assert "publisher" in get_calls[0].request.url
+    assert "publisher" in str(get_calls[0].request.url)
 
 
 @mock_aws
@@ -151,7 +157,7 @@ def test_get_propagates_500_from_serial_without_falling_back():
     assert result.exit_code != 0
     assert "500" in result.output
     publisher_calls = [
-        c for c in responses.calls if c.request.url.startswith(f"{PUBLISHER_URL}/")
+        c for c in responses.calls if str(c.request.url).startswith(f"{PUBLISHER_URL}/")
     ]
     assert publisher_calls == []
 
@@ -209,9 +215,9 @@ def test_create_with_isbn_creates_publisher():
 
     assert result.exit_code == 0, result.output
     post_calls = [c for c in responses.calls if c.request.method == "POST"]
-    publisher_posts = [c for c in post_calls if "publisher" in c.request.url]
+    publisher_posts = [c for c in post_calls if "publisher" in str(c.request.url)]
     assert len(publisher_posts) == 1
-    body = json.loads(publisher_posts[0].request.body)
+    body = _request_json(publisher_posts[0])
     assert body == {"name": "Acme", "isbnPrefix": "978-82-12"}
 
 
@@ -238,10 +244,10 @@ def test_create_with_print_issn_creates_serial_journal_by_default():
     serial_posts = [
         c
         for c in responses.calls
-        if c.request.method == "POST" and "serial" in c.request.url
+        if c.request.method == "POST" and "serial" in str(c.request.url)
     ]
     assert len(serial_posts) == 1
-    body = json.loads(serial_posts[0].request.body)
+    body = _request_json(serial_posts[0])
     assert body["type"] == "Journal"
 
 
@@ -268,7 +274,7 @@ def test_create_with_kind_series_uses_series_endpoint():
     series_posts = [
         c
         for c in responses.calls
-        if c.request.method == "POST" and c.request.url.endswith("/series")
+        if c.request.method == "POST" and str(c.request.url).endswith("/series")
     ]
     assert len(series_posts) == 1
 
@@ -296,10 +302,10 @@ def test_create_with_kind_journal_uses_journal_endpoint():
     journal_posts = [
         c
         for c in responses.calls
-        if c.request.method == "POST" and c.request.url.endswith("/journal")
+        if c.request.method == "POST" and str(c.request.url).endswith("/journal")
     ]
     assert len(journal_posts) == 1
-    body = json.loads(journal_posts[0].request.body)
+    body = _request_json(journal_posts[0])
     assert body == {"name": "Baz", "printIssn": "1234-5678"}
 
 
@@ -352,7 +358,7 @@ def test_update_auto_detects_kind_and_calls_serial_put():
     assert result.exit_code == 0, result.output
     put_calls = [c for c in responses.calls if c.request.method == "PUT"]
     assert len(put_calls) == 1
-    body = json.loads(put_calls[0].request.body)
+    body = _request_json(put_calls[0])
     assert body == {"type": "UpdateSerialPublicationRequest", "name": "New name"}
 
 
@@ -381,7 +387,7 @@ def test_update_serial_sends_issn_fields_in_body():
     assert result.exit_code == 0, result.output
     put_calls = [c for c in responses.calls if c.request.method == "PUT"]
     assert len(put_calls) == 1
-    body = json.loads(put_calls[0].request.body)
+    body = _request_json(put_calls[0])
     assert body == {
         "type": "UpdateSerialPublicationRequest",
         "printIssn": "1234-5678",
@@ -410,7 +416,7 @@ def test_update_publisher_uses_publisher_put_when_serial_returns_404():
     assert result.exit_code == 0, result.output
     put_calls = [c for c in responses.calls if c.request.method == "PUT"]
     assert len(put_calls) == 1
-    body = json.loads(put_calls[0].request.body)
+    body = _request_json(put_calls[0])
     assert body == {"type": "UpdatePublisherRequest", "name": "Acme", "isbn": "978-1"}
 
 
@@ -473,7 +479,7 @@ def test_search_kind_journal_calls_journal_endpoint_only():
     assert result.exit_code == 0, result.output
     get_calls = [c for c in responses.calls if c.request.method == "GET"]
     assert len(get_calls) == 1
-    assert get_calls[0].request.url.startswith(JOURNAL_URL)
+    assert str(get_calls[0].request.url).startswith(JOURNAL_URL)
 
 
 @mock_aws
@@ -539,7 +545,7 @@ def test_search_passes_year_query_param():
     get_calls = [c for c in responses.calls if c.request.method == "GET"]
     assert len(get_calls) == 2
     for call in get_calls:
-        assert "year=2024" in call.request.url
+        assert "year=2024" in str(call.request.url)
 
 
 @mock_aws
@@ -561,7 +567,7 @@ def test_get_appends_year_path_segment():
     assert result.exit_code == 0, result.output
     get_calls = [c for c in responses.calls if c.request.method == "GET"]
     assert len(get_calls) == 1
-    assert get_calls[0].request.url.endswith(f"/{AN_IDENTIFIER}/2024")
+    assert str(get_calls[0].request.url).endswith(f"/{AN_IDENTIFIER}/2024")
 
 
 def test_identifier_from_id_handles_year_suffix():

--- a/commands/services/tests/test_handle.py
+++ b/commands/services/tests/test_handle.py
@@ -161,7 +161,9 @@ def test_redirect_to_nva_updates_handle(tmp_path):
     assert "UPDATED" in result.output
     put_calls = [c for c in responses.calls if c.request.method == "PUT"]
     assert len(put_calls) == 1
-    assert A_IDENTIFIER in put_calls[0].request.body.decode()
+    request_body = put_calls[0].request.body
+    assert isinstance(request_body, bytes)
+    assert A_IDENTIFIER in request_body.decode()
     assert len(csv_rows) == 1
     assert csv_rows[0]["handle"] == A_HANDLE
     assert csv_rows[0]["status"] == "ok"

--- a/commands/services/tests/test_resource.py
+++ b/commands/services/tests/test_resource.py
@@ -16,17 +16,11 @@ def test_migrate_contributor_affiliations():
     resource.migrate_contributor_affiliations("10.1.0.0", "10.2.0.0")
 
     assert (
-        resource.data.get("entityDescription")
-        .get("contributors")[0]
-        .get("affiliations")[0]
-        .get("id")
+        resource.data["entityDescription"]["contributors"][0]["affiliations"][0]["id"]
         == "https://somehost/10.2.0.0"
     )
     assert (
-        resource.data.get("entityDescription")
-        .get("contributors")[1]
-        .get("affiliations")[0]
-        .get("id")
+        resource.data["entityDescription"]["contributors"][1]["affiliations"][0]["id"]
         == "https://somehost/10.2.0.0"
     )
 
@@ -39,6 +33,6 @@ def test_migrate_owner_affiliation():
     resource.migrate_owner_affiliation("10.1.0.0", "10.2.0.0")
 
     assert (
-        resource.data.get("resourceOwner").get("ownerAffiliation")
+        resource.data["resourceOwner"]["ownerAffiliation"]
         == "https://somehost/10.2.0.0"
     )

--- a/commands/services/tests/test_search_api.py
+++ b/commands/services/tests/test_search_api.py
@@ -71,7 +71,7 @@ def test_sends_identifying_user_agent():
 
     list(_a_service().resource_search({"aggregation": "none"}))
 
-    assert "nva-aws-cli-tools" in responses.calls[0].request.headers["User-Agent"]
+    assert "nva-aws-cli-tools" in str(responses.calls[0].request.headers["User-Agent"])
 
 
 @mock_aws
@@ -109,7 +109,7 @@ def test_follows_next_search_after_link_across_pages():
 
     assert [hit["identifier"] for hit in hits] == ["a", "b", "c"]
     assert len(responses.calls) == 2
-    assert "searchAfter=next-cursor" in responses.calls[1].request.url
+    assert "searchAfter=next-cursor" in str(responses.calls[1].request.url)
 
 
 @mock_aws
@@ -133,7 +133,7 @@ def test_next_page_keeps_cursor_and_sets_current_page_size():
     params = _query_params(responses.calls[1])
     assert params["searchAfter"] == "next-cursor"
     assert params["results"] == "2"
-    assert "version=2099-01-01" in second_request.headers["Accept"]
+    assert "version=2099-01-01" in str(second_request.headers["Accept"])
 
 
 @mock_aws

--- a/commands/services/user_models.py
+++ b/commands/services/user_models.py
@@ -12,9 +12,7 @@ class Role:
 
     @classmethod
     def from_dynamodb(cls, item: dict[str, Any]) -> Role:
-        access_rights = item.get("accessRights", [])
-        if isinstance(access_rights, set):
-            access_rights = list(access_rights)
+        access_rights = [str(right) for right in item.get("accessRights", [])]
         return cls(
             name=item.get("name", ""),
             access_rights=access_rights,
@@ -32,13 +30,14 @@ class ViewingScope:
 
     @classmethod
     def from_dynamodb(cls, item: dict[str, Any]) -> ViewingScope:
-        included_units = item.get("includedUnits", [])
-        if isinstance(included_units, set):
-            included_units = list(included_units)
+        included_units = [str(unit) for unit in item.get("includedUnits", [])]
 
-        excluded_units = item.get("excludedUnits")
-        if isinstance(excluded_units, set):
-            excluded_units = list(excluded_units)
+        excluded_units_raw = item.get("excludedUnits")
+        excluded_units = (
+            [str(unit) for unit in excluded_units_raw]
+            if excluded_units_raw is not None
+            else None
+        )
 
         return cls(
             included_units=included_units,

--- a/commands/sqs.py
+++ b/commands/sqs.py
@@ -113,7 +113,7 @@ def analyze(ctx: AppContext, folder_path: str) -> None:
         raise click.Abort()
 
 
-@sqs.command()
+@sqs.command(name="list")
 @click.option("--filter", type=str, help="Filter queues by name pattern")
 @click.option(
     "--include-empty",
@@ -121,7 +121,7 @@ def analyze(ctx: AppContext, folder_path: str) -> None:
     help="Include queues with no messages available or in flight",
 )
 @click.pass_obj
-def list(ctx: AppContext, filter: str | None, include_empty: bool) -> None:
+def list_queues(ctx: AppContext, filter: str | None, include_empty: bool) -> None:
     """List SQS queues with message counts.
 
     By default only queues with messages available or in flight are shown.

--- a/commands/tests/test_awslambda_cli.py
+++ b/commands/tests/test_awslambda_cli.py
@@ -1,6 +1,7 @@
 import io
 import json
 import zipfile
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -113,8 +114,11 @@ def test_concurrency_writes_functions_sorted_desc_by_reserved_concurrency(
 def _build_session_with_stubbed_lambda(fake_lambda) -> boto3.Session:
     session = boto3.Session()
     real_client = session.client
-    session.client = lambda name, *args, **kwargs: (
-        fake_lambda if name == "lambda" else real_client(name, *args, **kwargs)
+    session.client = cast(
+        Any,
+        lambda name, *args, **kwargs: (
+            fake_lambda if name == "lambda" else real_client(name, *args, **kwargs)
+        ),
     )
     return session
 

--- a/commands/tests/test_pipelines_cli.py
+++ b/commands/tests/test_pipelines_cli.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -10,10 +11,13 @@ from cli import cli
 def _build_session_with_stubbed_codepipeline(fake_codepipeline) -> boto3.Session:
     session = boto3.Session()
     real_client = session.client
-    session.client = lambda name, *args, **kwargs: (
-        fake_codepipeline
-        if name == "codepipeline"
-        else real_client(name, *args, **kwargs)
+    session.client = cast(
+        Any,
+        lambda name, *args, **kwargs: (
+            fake_codepipeline
+            if name == "codepipeline"
+            else real_client(name, *args, **kwargs)
+        ),
     )
     return session
 

--- a/commands/tests/test_search_cli.py
+++ b/commands/tests/test_search_cli.py
@@ -45,6 +45,7 @@ def test_format_hit_line_id_only_missing_identifier_returns_none():
 def test_format_hit_line_compact_is_single_line_json():
     line = _format_hit_line({"identifier": "abc", "x": 1}, id_only=False, compact=True)
 
+    assert line is not None
     assert "\n" not in line
     assert json.loads(line) == {"identifier": "abc", "x": 1}
 
@@ -52,6 +53,7 @@ def test_format_hit_line_compact_is_single_line_json():
 def test_format_hit_line_pretty_is_indented():
     line = _format_hit_line({"identifier": "abc"}, id_only=False, compact=False)
 
+    assert line is not None
     assert "\n" in line
 
 
@@ -60,7 +62,9 @@ def test_jsonl_sink_rotates_into_batches(tmp_path):
 
     with _JsonlSink(base, batch_size=1000) as sink:
         for index in range(2500):
-            sink.write(_format_hit_line(_a_hit(f"id-{index}"), False, True))
+            line = _format_hit_line(_a_hit(f"id-{index}"), False, True)
+            assert line is not None
+            sink.write(line)
 
     files = sorted(
         os.path.basename(path) for path in glob.glob(str(tmp_path / "*.jsonl"))
@@ -160,7 +164,7 @@ def test_exclude_fields_sets_nodes_excluded_query_param():
         )
 
     assert result.exit_code == 0, result.output
-    query = urllib.parse.urlparse(responses.calls[0].request.url).query
+    query = urllib.parse.urlparse(str(responses.calls[0].request.url)).query
     params = dict(urllib.parse.parse_qsl(query))
     assert params["nodesExcluded"] == "contributorsPreview,tags,otherIdentifiers"
 

--- a/commands/tests/test_sws_cli.py
+++ b/commands/tests/test_sws_cli.py
@@ -76,6 +76,6 @@ def test_get_mappings_targets_prod_endpoints_when_env_is_prod():
     )
 
     assert result.exit_code == 0, result.exception
-    called_urls = [call.request.url for call in responses.calls]
+    called_urls = [str(call.request.url) for call in responses.calls]
     assert any(TOKEN_ENDPOINT_PROD in url for url in called_urls)
     assert any(API_ENDPOINT_PROD in url for url in called_urls)

--- a/commands/tests/test_users_cli.py
+++ b/commands/tests/test_users_cli.py
@@ -94,9 +94,12 @@ def test_add_user_posts_to_users_roles_endpoint():
     post_call = next(
         call
         for call in responses.calls
-        if call.request.method == "POST" and "users-roles/users" in call.request.url
+        if call.request.method == "POST"
+        and "users-roles/users" in str(call.request.url)
     )
-    assert json.loads(post_call.request.body) == payload
+    request_body = post_call.request.body
+    assert isinstance(request_body, (str, bytes))
+    assert json.loads(request_body) == payload
 
 
 @mock_aws

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,11 @@ addopts = "--cov=commands --cov=cli --cov-report=term-missing --cov-fail-under=7
 
 [dependency-groups]
 dev = [
+    "boto3-stubs[codepipeline,cognito-idp,dynamodb,iam,lambda,s3,secretsmanager,sqs,ssm,sts]>=1.43.63",
     "moto[awslambda-simple,cognitoidp,ssm]>=5.2.2",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "responses>=0.26.1",
     "ruff>=0.16.1",
+    "ty>=0.0.66",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,51 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3-stubs"
+version = "1.43.63"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/65/7af76ab7ad98474174ce5a8f51a8687853b9ce4118dbe4e00dca49905b05/boto3_stubs-1.43.63.tar.gz", hash = "sha256:31d8d1baa9270bfdfc070657710727fc792790967ad9888864ebffb3723660f9", size = 103440, upload-time = "2026-08-03T19:59:28.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/11/5b25cadd366a5d234df3ea60822c2148a0c3d188c12e7ea2c8893e82edb2/boto3_stubs-1.43.63-py3-none-any.whl", hash = "sha256:4da5bb38e6d2baf34937818c841eed6b0dc80db434bf8f6fea2b47de69781c75", size = 71073, upload-time = "2026-08-03T19:59:24.445Z" },
+]
+
+[package.optional-dependencies]
+codepipeline = [
+    { name = "mypy-boto3-codepipeline" },
+]
+cognito-idp = [
+    { name = "mypy-boto3-cognito-idp" },
+]
+dynamodb = [
+    { name = "mypy-boto3-dynamodb" },
+]
+iam = [
+    { name = "mypy-boto3-iam" },
+]
+lambda = [
+    { name = "mypy-boto3-lambda" },
+]
+s3 = [
+    { name = "mypy-boto3-s3" },
+]
+secretsmanager = [
+    { name = "mypy-boto3-secretsmanager" },
+]
+sqs = [
+    { name = "mypy-boto3-sqs" },
+]
+ssm = [
+    { name = "mypy-boto3-ssm" },
+]
+sts = [
+    { name = "mypy-boto3-sts" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.43.63"
 source = { registry = "https://pypi.org/simple" }
@@ -28,6 +73,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/5f/b33913aab846bc88a2720976435adb944d1ef57b92beed829233fe1953d9/botocore-1.43.63.tar.gz", hash = "sha256:854e45247f00b0732496ea1f0c5d0cf3c31d58b48eb052c31c27ab1087dfddf1", size = 15824662, upload-time = "2026-08-03T19:54:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/ae/8ddbf97a12fba9b6ce50ac1c2209ebd2ab3b240229a1fbe5de66ffcbd05f/botocore-1.43.63-py3-none-any.whl", hash = "sha256:8deed86feacc8f8d2491f1d170562af191f8b33924052d834f4217d5d797e5a9", size = 15509076, upload-time = "2026-08-03T19:54:52.455Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/81/79693e833291c00dc89ee610e5e915381b6f08233912e28df50106840780/botocore_stubs-1.43.14.tar.gz", hash = "sha256:9e3bc1fdd51da7473f0df726c82747a1b0ae913449d629659765c247fecc2039", size = 42738, upload-time = "2026-05-25T06:06:37.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ca/f017727b11895908c5dedc829cf2ec35e0c4b2a26ba875db325fef2cefdf/botocore_stubs-1.43.14-py3-none-any.whl", hash = "sha256:fb98f1475c92fd718644e786b5c543a20f1b1f610e89e0a7191c3f1f429c75aa", size = 67093, upload-time = "2026-05-25T06:06:34.532Z" },
 ]
 
 [[package]]
@@ -399,6 +456,96 @@ ssm = [
 ]
 
 [[package]]
+name = "mypy-boto3-codepipeline"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/75/9c963112681352aee9756b0c0ec1ea290f8b891c123bb09b122c5ee8d5f1/mypy_boto3_codepipeline-1.43.0.tar.gz", hash = "sha256:346a885efc8137aaf28bdd62c95b021e220fd986164f5d237e3ca6476a5539f1", size = 37277, upload-time = "2026-04-29T22:58:52.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/25/028923b3f8d77846ff020f36b6e3904b26b723a55f49f8bdb3d5dcebb24a/mypy_boto3_codepipeline-1.43.0-py3-none-any.whl", hash = "sha256:3a0b881c630f4117e2dafa6c904154f6772d1001be5ef2f1dae0e3d5c006fa08", size = 42437, upload-time = "2026-04-29T22:58:50.631Z" },
+]
+
+[[package]]
+name = "mypy-boto3-cognito-idp"
+version = "1.43.56"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/23/489e6ab48587f76f9dd263292b605e3490db7e9aea4a6f80363bb950ee01/mypy_boto3_cognito_idp-1.43.56.tar.gz", hash = "sha256:d6e9cb2ba284fa8d3b51da334b56ae5c559f9b5c25c0f200c64473464088c9a6", size = 55023, upload-time = "2026-07-24T20:10:15.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/3e/552d48ab267b271157d738a7703f31eaaaf8380acbb9ac03c855191c4abb/mypy_boto3_cognito_idp-1.43.56-py3-none-any.whl", hash = "sha256:0ec9a68ed61c8e2e0997c00b1ea2e7cf7bded296be72ae978d6ab346c9c4dd4d", size = 61346, upload-time = "2026-07-24T20:10:12.284Z" },
+]
+
+[[package]]
+name = "mypy-boto3-dynamodb"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/41/2823aad9f3abab6104cd8aaafebabfba19927227fbc277e2289c3b915c1d/mypy_boto3_dynamodb-1.43.0.tar.gz", hash = "sha256:f0cea38e058f1d07361ecb55d8f40665d824b42cf4864724c7fccc8bf3946fcd", size = 48755, upload-time = "2026-04-29T22:59:59.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/e2/1f63f04600fc21cb848c10ce16490252e27d812bfd5a716659283049d3a3/mypy_boto3_dynamodb-1.43.0-py3-none-any.whl", hash = "sha256:60b64d15e86d406a980d96f734d8c7fb1704668d0234dc8dabd2532c902a3ba6", size = 58873, upload-time = "2026-04-29T22:59:56.823Z" },
+]
+
+[[package]]
+name = "mypy-boto3-iam"
+version = "1.43.60"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/9b/f34afc2b2d2760203f9ee48df5f660206972f43a31905ce2995b4fa6f999/mypy_boto3_iam-1.43.60.tar.gz", hash = "sha256:4a1f36a68cb3f962c000f2056204346d1c19616a1227997c5707b2639e734d83", size = 89756, upload-time = "2026-07-30T20:10:59.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/03/cabf1ccdce5ed97eeb5abb955251cd77037df0f2f97fb97b56a8e8230033/mypy_boto3_iam-1.43.60-py3-none-any.whl", hash = "sha256:623834c0cc0c728e716c56936217b4b2fa920f7ae78a4fcfdf7a133e2525588e", size = 95599, upload-time = "2026-07-30T20:10:55.687Z" },
+]
+
+[[package]]
+name = "mypy-boto3-lambda"
+version = "1.43.60"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/77/7cebb2f0b88680cdf91eaa1c33fb88e0cbd27b4387fd352a8d7bcbc4c68d/mypy_boto3_lambda-1.43.60.tar.gz", hash = "sha256:c0f7e6d984c0fc5120966786915ef3012e9ccc9d382de412e0b71f309667851c", size = 52628, upload-time = "2026-07-30T20:11:07.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ab/712f39d92c602931176661e00259e037f439a7982df11f3ce05ea4d01069/mypy_boto3_lambda-1.43.60-py3-none-any.whl", hash = "sha256:bc097cdcb8d4a87e2685551bbaf39e583f1b603b38a6b45c784df83847819971", size = 61105, upload-time = "2026-07-30T20:11:02.711Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3"
+version = "1.43.50"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/e6/83141bd1cb8e060ecfd98ba23cfc295eae0123194add7d02e16d6d7e211e/mypy_boto3_s3-1.43.50.tar.gz", hash = "sha256:206817d22e80795da35daf704225f2e2a2b561fa4bf8c609f2150b04800ae811", size = 78807, upload-time = "2026-07-16T19:56:32.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/f4/39480da24fe26490234d081bc36b967a6ed1b592507d459a94338558bc35/mypy_boto3_s3-1.43.50-py3-none-any.whl", hash = "sha256:778aa2a48314ea47aeccca48ae151fe208b48d568d02578494b7201621ff2d6a", size = 86184, upload-time = "2026-07-16T19:56:30.283Z" },
+]
+
+[[package]]
+name = "mypy-boto3-secretsmanager"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e0/3b9f954dcce063407224e6601ed5af2d684185387b0572901c5f984fc8f6/mypy_boto3_secretsmanager-1.43.0.tar.gz", hash = "sha256:265ee2fddf9d3e42ae39685625fb7861a539110d8e324372847c0e1cbd666b20", size = 19967, upload-time = "2026-04-29T23:05:45.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/93/ae939d61eed240972553395b5e31f780825685b99f0ab4ebe5767430f103/mypy_boto3_secretsmanager-1.43.0-py3-none-any.whl", hash = "sha256:38415cdecb73dd20e485707a7cf456f6dde54ff4b155e7fb255eb001eb47d5bc", size = 27335, upload-time = "2026-04-29T23:05:43.152Z" },
+]
+
+[[package]]
+name = "mypy-boto3-sqs"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/1e/226725696a99c7dadfe8ebfba01575107fa15146029a7fb0082c650d8689/mypy_boto3_sqs-1.43.0.tar.gz", hash = "sha256:3ec8e1e651e830affcf7fe151b2e3090b8ea98d73cb069053b09ca4c7f4c8636", size = 23318, upload-time = "2026-04-29T23:06:17.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/5e/5d4deb1ee7aec7fcdddbca616c623f07bfc72a1cd3e80b0e2a0c39904fae/mypy_boto3_sqs-1.43.0-py3-none-any.whl", hash = "sha256:f90225486756a4041db9f056967cb3cee202264bbe57682031c1e94d83e8ca39", size = 33604, upload-time = "2026-04-29T23:06:15.339Z" },
+]
+
+[[package]]
+name = "mypy-boto3-ssm"
+version = "1.43.53"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/a5/f43b2c755cf3ad6c61821f54802d13acf3831deb378d90e68f5ced332063/mypy_boto3_ssm-1.43.53.tar.gz", hash = "sha256:f20a2f1035a0d58b61647c6f5c883e058152acdccd8a97e7d1916476dc8e7c7b", size = 97766, upload-time = "2026-07-21T19:52:31.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/97/b2cf5f41d412891e8122e5e6a1986c7ebcdff3c9d5ac90058e045c65a816/mypy_boto3_ssm-1.43.53-py3-none-any.whl", hash = "sha256:d90a5a46e2e5db78ae5354d6cf925be81567704d4d051337feef79b8cfd6d3de", size = 99501, upload-time = "2026-07-21T19:52:28.759Z" },
+]
+
+[[package]]
+name = "mypy-boto3-sts"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/fd/74a557327cc0a5f6cecb9671ab983bc186bcabb9ae95372c467f4fd32669/mypy_boto3_sts-1.43.0.tar.gz", hash = "sha256:7c38cffd0f07ff226d0b8016610bf5fa19bd6fa2a75a04cfdeecba2cabea8a4c", size = 16808, upload-time = "2026-04-29T23:06:35.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/1e/0a49da78a63c4ae8b315bb786364d0262578b70273aa42f82609136be3ec/mypy_boto3_sts-1.43.0-py3-none-any.whl", hash = "sha256:a7523d0a5c67af3ff814eaa93458087fcf6d389402c50f4bd3c1e82a5ebdd94a", size = 20845, upload-time = "2026-04-29T23:06:32.539Z" },
+]
+
+[[package]]
 name = "nva-aws-cli-tools"
 version = "0.1.0"
 source = { virtual = "." }
@@ -420,11 +567,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3-stubs", extra = ["codepipeline", "cognito-idp", "dynamodb", "iam", "lambda", "s3", "secretsmanager", "sqs", "ssm", "sts"] },
     { name = "moto", extra = ["cognitoidp", "ssm"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -446,11 +595,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3-stubs", extras = ["codepipeline", "cognito-idp", "dynamodb", "iam", "lambda", "s3", "secretsmanager", "sqs", "ssm", "sts"], specifier = ">=1.43.63" },
     { name = "moto", extras = ["awslambda-simple", "cognitoidp", "ssm"], specifier = ">=5.2.2" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "responses", specifier = ">=0.26.1" },
     { name = "ruff", specifier = ">=0.16.1" },
+    { name = "ty", specifier = ">=0.0.66" },
 ]
 
 [[package]]
@@ -719,6 +870,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.66"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/58/4f6ab2a86589e422a3cf840bcf6114c565e4c39ddf4d0b7cd328af5b52b4/ty-0.0.66.tar.gz", hash = "sha256:24bddd4479ce445b51ac015410dd2d34af1cadd62a77f5b3cb269149ed83f9b5", size = 6520402, upload-time = "2026-08-04T01:09:47.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/4d/bbc28310d6d887ef73e5800f062c4bf54caa35a1b47d70c7b03d0515ecf1/ty-0.0.66-py3-none-linux_armv6l.whl", hash = "sha256:8b46450438b54b732338e4d7a78a7d2f5e1a012a13d77d121aacaca20fb814e2", size = 12409743, upload-time = "2026-08-04T01:09:01.229Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/c3d2eb2242fa0a2ef445ca2c7009dc9118e5b3dcb8b8a8bec70d58c8e4bc/ty-0.0.66-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8e4adbe662bc3c62b52b83d46b07f703fdc3c123bb72601606c58be5ea017ed3", size = 12078362, upload-time = "2026-08-04T01:09:04.233Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/7a4b5e45d701a8de6b714dacf6ffca91b0411baaceaa781d494037623a18/ty-0.0.66-py3-none-macosx_11_0_arm64.whl", hash = "sha256:776814351735847eb934f9a3cbea21d2278ba14aa0fc099f683da11bc2d5c90a", size = 11583289, upload-time = "2026-08-04T01:09:06.973Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/fbb1f71ee2999f981f8c4b3b139231e4bcff4ede0c3b37e858fd1334ed26/ty-0.0.66-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cca1da877f613965b954bfd22d495386e260ec767c5536c8022cca98a260ea5d", size = 12137274, upload-time = "2026-08-04T01:09:09.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/9e0662f6603a5ac171ae6b314396e677ead4b45695fc948efb0a4837051f/ty-0.0.66-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa523e777bc36c0fbf8ded5844096f46cbfc3712fe5a003351a94259b7e86cf4", size = 12207047, upload-time = "2026-08-04T01:09:12.533Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cc/12e01bc2ea47fa7bf20fc6cdd3249d6a340be9be4edc52b1d77256245dd0/ty-0.0.66-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f7993c1f95f80a4e44056e6aaf8e46e608d778db131ae5ce59262ab59358f9a", size = 12919304, upload-time = "2026-08-04T01:09:15.175Z" },
+    { url = "https://files.pythonhosted.org/packages/75/88/c6c0d3a8e71c9cdb560cc5c627a4bba6c47b5eec460b2f8c449b57c6d03a/ty-0.0.66-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b29354bcbac9f53b6952d8f46789bd81eeb9bdd7a68df7d26e654ca7498c3c", size = 13470963, upload-time = "2026-08-04T01:09:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c2/2f8c18063412ad80e1b3f87afce7bd50982b4a048166607b67f80660a9fb/ty-0.0.66-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbf4e5325f7f584d9c346946e7c415b2e3cd3b8f1119d468082a90a6afd020ce", size = 13244773, upload-time = "2026-08-04T01:09:20.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f6/fdae2b95831116dffc055ad53a99a8f21437263651047b3ad46def4950a3/ty-0.0.66-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bd304363764bd723c22fb20b17035c345420fdf66fee856934b158ebde08a91", size = 12751343, upload-time = "2026-08-04T01:09:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/7e75f0371d11463a256dc2bee98b0df401e0fa06021e200b8b601d21949d/ty-0.0.66-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:205d8589bd957ea9718d488b731b2fbdd0d1b1cefd37c79f52c0deb7cafddfef", size = 13068057, upload-time = "2026-08-04T01:09:26.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/84/f20f24518f6f0bea936e2e668ede250b9ce0774624559931599bd1f42772/ty-0.0.66-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7304a1df54741a2343801354f41d7ad87974acb541ee3e93c26cb6a1a0b863af", size = 12082318, upload-time = "2026-08-04T01:09:28.877Z" },
+    { url = "https://files.pythonhosted.org/packages/08/20/70ca0eac2427d4a58a81a3a9426b20e46fb4a5a13aefc9edc2e5172e1243/ty-0.0.66-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cf2c062863e5da0f588b0b120fec0da2e81c0913ee4cd07b50d77aa60ffd8deb", size = 12228978, upload-time = "2026-08-04T01:09:31.905Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/01/5a461ab34456d788248780830aed673c9e0e796f6e9dd92d3dbf02e04d7f/ty-0.0.66-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a58d32c879d86428978332adf21e85009ec269314a23d330c3483c65b57aedc7", size = 12471917, upload-time = "2026-08-04T01:09:34.418Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ed/f8eb5eff7c9ee644490c6d2626425935c097acc54871adf659ea70624a2c/ty-0.0.66-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2f810fa3516c977630d78dbe9161592b3c27029fa9bb81074366624d9b5e4b6", size = 12858086, upload-time = "2026-08-04T01:09:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7f/8a78361f752274a550a7f6f07f127b246ece7d7fdde31121d22074e46eab/ty-0.0.66-py3-none-win32.whl", hash = "sha256:d28c3df565a387c1c5ea359aa452a46d19163616ef71be819058a424a62f1ae1", size = 11782494, upload-time = "2026-08-04T01:09:40.136Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e2/deed22b823ce309b8410d50414fd15afe9e90aee8b8ca04789ba55c21231/ty-0.0.66-py3-none-win_amd64.whl", hash = "sha256:e3a457f3312c078f24c47d0da6e4f73de34d0a77ed2de22571c066c80b2fd5e7", size = 12893338, upload-time = "2026-08-04T01:09:42.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ce/6c828f42ef1ed39f53f57f9c0cdcdf03e23666fa7a29d799042a2c34bcb4/ty-0.0.66-py3-none-win_arm64.whl", hash = "sha256:2f62ae247b9c75674fcc060635f9f00210357da7681de59234d97b50fb9e9e94", size = 12227381, upload-time = "2026-08-04T01:09:45.365Z" },
+]
+
+[[package]]
+name = "types-awscrt"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds static typechecking with [ty](https://docs.astral.sh/ty/) and [boto3-stubs](https://youtype.github.io/boto3_stubs_docs/), with a new `uv run ty check` step in CI.
The initial run reported 70 diagnostics.
All are fixed rather than suppressed, so the check now passes cleanly.

Most fixes are corrected annotations, typed AWS payloads via the stubs' TypedDicts, and tightened test assertions.
The checker also surfaced a few real issues:

- `commands/sqs.py`: the click command `list` shadowed the builtin, breaking `list[...]` annotations later in the module. Renamed to `list_queues`, the CLI is unchanged.
- `pipelines.py`: `get_details_from_pipeline_execution` could return `None`, which callers dereference. It now returns a placeholder `ExecutionDetails` instead.
- `resource_batch_job.py`: `_validate_publication_id` claimed `-> bool` but returned `Match | None`.